### PR TITLE
Rewrite sprite image processing pipeline from Win2D to NetVips

### DIFF
--- a/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
+++ b/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
@@ -42,7 +42,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+    <PackageReference Include="NetVips" Version="3.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
   </ItemGroup>

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -1,25 +1,19 @@
-﻿using Microsoft.Graphics.Canvas;
-using Microsoft.Graphics.Canvas.Effects;
-using Microsoft.Graphics.Canvas.UI;
+﻿using NetVips;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
-
-
 namespace FramesToMMSpriteResources
 {
-    class ProcessedSprite(CanvasBitmap image, IntVector2 originalSize, IntVector2 trimOffset, string animationName, JsonObject? oldFrameJson)
+    class ProcessedSprite(Image image, IntVector2 originalSize, IntVector2 trimOffset, string animationName, JsonObject? oldFrameJson)
     {
-        public CanvasBitmap Image = image;
+        public Image Image = image;
         public IntVector2 OriginalSize = originalSize;
         public IntVector2 TrimOffset = trimOffset;
         public string AnimationName = animationName;
@@ -41,7 +35,6 @@ namespace FramesToMMSpriteResources
 
     class Processer
     {
-        private static readonly CanvasDevice SharedCanvasDevice = new CanvasDevice();
         private const double MaxColorDistance = 441.6729559300637;
         static ProgramConfig programConfig;
         static GameThemeConfig gameThemeConfig;
@@ -62,17 +55,17 @@ namespace FramesToMMSpriteResources
 
 
             string subjectPath = MainWindow.usingGameThemes ?
-            
+
                 Path.Combine(MainWindow.workingPath, programConfig.SelectedNode[0], programConfig.SelectedNode[1])
             :
-            
+
                 Path.Combine(MainWindow.workingPath, programConfig.SelectedNode[1]);
 
             List<ProcessedSprite> processedSprites = [];
-            List<Dictionary< string, object>> animationsMeta = [];
+            List<Dictionary<string, object>> animationsMeta = [];
             int frameIndex = 0;
 
-       
+
 
             string subPositions = string.Empty;
             PreviousSpriteFileValues previousSpriteFile = null;
@@ -85,13 +78,13 @@ namespace FramesToMMSpriteResources
 
             if (File.Exists(spriteFilePath))
             {
-            
+
                 var txt = File.ReadAllText(spriteFilePath);
                 var spritePayload = JsonNode.Parse(txt)?.AsObject();
 
                 frames = spritePayload?["Frames"]?.AsArray();
                 named = spritePayload?["NamedAnimations"]?.AsArray();
-         
+
 
                 var result = new PreviousSpriteFileValues
                 {
@@ -99,10 +92,10 @@ namespace FramesToMMSpriteResources
                     SubPositions = spritePayload?["SubPositions"]?.GetValue<string>()
                 };
 
-               
+
 
             }
-        
+
 
 
             foreach (var (animationName, animationConfig) in subjectConfig.AnimationConfigs)
@@ -117,7 +110,7 @@ namespace FramesToMMSpriteResources
 
                         var name = entry["Name"]?.GetValue<string>();
                         if (name == null || animationName != name) continue;
-             
+
 
                         var framesField = entry["Frames"]?.GetValue<string>() ?? string.Empty;
 
@@ -134,13 +127,13 @@ namespace FramesToMMSpriteResources
 
                             if (frames[idx] is JsonObject frameObj)
                                 list.Add(frameObj);
-                           
+
                         }
                         break;
 
                     }
                 }
-               
+
 
                 int spritesCount = 0;
                 string animationPath = Path.Combine(subjectPath, "raw", animationName);
@@ -149,11 +142,11 @@ namespace FramesToMMSpriteResources
                 var i = 0;
                 foreach (var spritePath in filesInAnimationPath)
                 {
-                
+
                     if (Path.GetExtension(spritePath) == ".png")
                     {
-                  
-                        var image = await CanvasBitmap.LoadAsync(SharedCanvasDevice, spritePath);
+
+                        var image = LoadImage(spritePath);
                         if (!string.IsNullOrEmpty(subjectConfig.BackgroundColor) && subjectConfig.RemoveBackground)
                         {
                             image = RemoveColorWithThreshold(image);
@@ -162,15 +155,15 @@ namespace FramesToMMSpriteResources
                         if (subjectConfig.ResizeToPercent != 100 && subjectConfig.ResizeToPercent > 0)
                         {
                             var scale = subjectConfig.ResizeToPercent / 100.0;
-                            int newW = Math.Max(1, (int)Math.Round(image.SizeInPixels.Width * scale));
-                            int newH = Math.Max(1, (int)Math.Round(image.SizeInPixels.Height * scale));
-                            if (newW != image.SizeInPixels.Width || newH != image.SizeInPixels.Height)
+                            int newW = Math.Max(1, (int)Math.Round(image.Width * scale));
+                            int newH = Math.Max(1, (int)Math.Round(image.Height * scale));
+                            if (newW != image.Width || newH != image.Height)
                                 image = ResizeBitmapNearest(image, new IntVector2(newW, newH));
                         }
 
-                        var originalSize = new IntVector2((int)image.SizeInPixels.Width, (int)image.SizeInPixels.Height);
+                        var originalSize = new IntVector2(image.Width, image.Height);
 
-                        (CanvasBitmap imgAfterTrim, IntVector2 offset) = (image, new(0, 0));
+                        (Image imgAfterTrim, IntVector2 offset) = (image, new(0, 0));
 
                         if (subjectConfig.CropSprites)
                         {
@@ -181,16 +174,16 @@ namespace FramesToMMSpriteResources
                         {
                             image = EnsureEvenDimensions(image);
                         }
-          
+
                         JsonObject oldJson = null;
-                        if(list != null)
+                        if (list != null)
                         {
                             oldJson = list[i];
                         }
                         processedSprites.Add(new ProcessedSprite(image, originalSize, offset, animationName, oldJson));
                         spritesCount++;
                         i++;
-                    }                 
+                    }
                 }
                 var frameRange = Enumerable.Range(frameIndex, spritesCount).ToList();
                 animationsMeta.Add(new Dictionary<string, object>
@@ -211,17 +204,19 @@ namespace FramesToMMSpriteResources
 
             var sheetImage = CreateSpriteSheet(processedSprites, finalPositions, canvasSize);
 
-    
+
 
             var payload = ExportSpriteMetadata(processedSprites, finalPositions, canvasSize, animationsMeta, subPositions);
 
-     
+
 
             if (Directory.Exists(outputDir))
             {
                 foreach (var child in Directory.EnumerateFiles(outputDir))
                 {
-                    try { File.Delete(child); } catch (Exception ex) { Debug.WriteLine(ex.Message); Debug.WriteLine(ex.StackTrace);
+                    try { File.Delete(child); } catch (Exception ex)
+                    {
+                        Debug.WriteLine(ex.Message); Debug.WriteLine(ex.StackTrace);
                     }
                 }
             }
@@ -231,31 +226,41 @@ namespace FramesToMMSpriteResources
             var spritesheetPath2x = spritesheetPath;
             if (gameThemeConfig.IsHd)
             {
-                int halfW = Math.Max(1, ((int)sheetImage.SizeInPixels.Width + 1) / 2);
-                int halfH = Math.Max(1, ((int)sheetImage.SizeInPixels.Height + 1) / 2);
+                int halfW = Math.Max(1, (sheetImage.Width + 1) / 2);
+                int halfH = Math.Max(1, (sheetImage.Height + 1) / 2);
                 var sheetHalf = ResizeBitmapNearest(sheetImage, new IntVector2(halfW, halfH));
-                SaveCanvasBitmapToFile(sheetHalf, spritesheetPath);
+                SaveImageToFile(sheetHalf, spritesheetPath);
                 spritesheetPath2x = Path.Combine(outputDir, programConfig.SelectedNode[1] + "@2x.png");
             }
-            SaveCanvasBitmapToFile(sheetImage, spritesheetPath2x);
+            SaveImageToFile(sheetImage, spritesheetPath2x);
 
             var options = new JsonSerializerOptions
             {
                 WriteIndented = true
             };
             File.WriteAllText(spriteFilePath, payload.ToJsonString(options));
+            await Task.CompletedTask;
         }
 
-        private static void SaveCanvasBitmapToFile(CanvasBitmap bmp, string path)
+        private static Image LoadImage(string path)
+        {
+            var image = Image.NewFromFile(path, access: Enums.Access.Sequential);
+            if (image.Bands == 4) return image;
+            if (image.Bands == 3)
+            {
+                var alpha = Image.Black(image.Width, image.Height) + 255;
+                return image.Bandjoin(alpha);
+            }
+            throw new InvalidOperationException($"Unsupported band count: {image.Bands} in {path}");
+        }
+
+        private static void SaveImageToFile(Image image, string path)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-
-            //TODO: OPTIMALIZÁCIÓ TOGGLE
-            bmp.SaveAsync(path, CanvasBitmapFileFormat.Png)
-               .AsTask().GetAwaiter().GetResult();
+            image.WriteToFile(path);
         }
 
-  
+
         private static JsonObject ExportSpriteMetadata(List<ProcessedSprite> sprites, List<IntVector2?> positions, IntVector2 canvasSize, List<Dictionary<string, object>> animations, string subPositions)
         {
             int sourceWidth = canvasSize.X;
@@ -272,7 +277,7 @@ namespace FramesToMMSpriteResources
                 var position = positions[i];
                 int left = position?.X ?? 0; int top = position?.Y ?? 0;
                 var bmp = sprite.Image;
-                IntVector2 size = new((int)bmp.SizeInPixels.Width, (int)bmp.SizeInPixels.Height);
+                IntVector2 size = new(bmp.Width, bmp.Height);
                 var orig = sprite.OriginalSize;
                 double leftScaled = left; double topScaled = top; double rightScaled = left + size.X; double bottomScaled = top + size.Y;
 
@@ -286,11 +291,11 @@ namespace FramesToMMSpriteResources
 
                 JsonObject frameValues;
                 if (sprite.OldFrameJson == null)
-                { 
+                {
                     var trim = sprite.TrimOffset;
                     AnimationConfig animConfig = subjectConfig.AnimationConfigs[sprite.AnimationName];
                     var recover = animConfig.RecoverCroppedOffset;
-              
+
                     int trimLeft = trim.X; int trimTop = trim.Y;
                     int originalWidth = orig.X; int originalHeight = orig.Y;
                     if (!recover.X)
@@ -328,7 +333,7 @@ namespace FramesToMMSpriteResources
                 }
                 else
                 {
-                
+
 
                     frameValues = sprite.OldFrameJson.DeepClone().AsObject();
                 }
@@ -357,22 +362,18 @@ namespace FramesToMMSpriteResources
             return payload;
         }
 
-        static CanvasBitmap CreateSpriteSheet(List<ProcessedSprite> sprites, List<IntVector2?> positions, IntVector2 canvasSize)
+        static Image CreateSpriteSheet(List<ProcessedSprite> sprites, List<IntVector2?> positions, IntVector2 canvasSize)
         {
             if (canvasSize.X <= 1 || canvasSize.Y <= 1) throw new InvalidOperationException("Sprites don't exist.");
-            var rt = new CanvasRenderTarget(SharedCanvasDevice, canvasSize.X, canvasSize.Y, 96);
-            using (var ds = rt.CreateDrawingSession())
+            var sheet = Image.Black(canvasSize.X, canvasSize.Y, bands: 4);
+            for (int i = 0; i < sprites.Count; i++)
             {
-                ds.Clear(Microsoft.UI.Colors.Transparent);
-                for (int i = 0; i < sprites.Count; i++)
-                {
-                    var pos = positions[i];
-                    if (pos == default) continue;
-                    var bmp = (CanvasBitmap)sprites[i].Image;
-                    ds.DrawImage(bmp, new Windows.Foundation.Rect(pos?.X ?? 0, pos?.Y ?? 0, bmp.SizeInPixels.Width, bmp.SizeInPixels.Height));
-                }
+                var pos = positions[i];
+                if (pos == default) continue;
+                var bmp = sprites[i].Image;
+                sheet = sheet.Insert(bmp, pos?.X ?? 0, pos?.Y ?? 0, expand: false, background: [0, 0, 0, 0]);
             }
-            return rt;
+            return sheet;
         }
 
         static LayoutInfo SelectLayout(List<ProcessedSprite> sprites)
@@ -397,8 +398,8 @@ namespace FramesToMMSpriteResources
         private static (IntVector2 size, List<IntVector2?> positions) LayoutForWidth(List<ProcessedSprite> sprites, int widthLimit)
         {
             int gap = gameThemeConfig.IsHd ? 2 : 1;
-            if (sprites.Count == 0) return (new(0,0), new List<IntVector2?>());
-            int maxSpriteWidth = sprites.Max(s => (int)s.Image.SizeInPixels.Width);
+            if (sprites.Count == 0) return (new(0, 0), new List<IntVector2?>());
+            int maxSpriteWidth = sprites.Max(s => s.Image.Width);
             if (widthLimit < maxSpriteWidth) throw new InvalidOperationException("width_limit is smaller than the widest sprite.");
 
             var rows = new List<(List<int> indices, int width, int height)>();
@@ -408,8 +409,8 @@ namespace FramesToMMSpriteResources
             for (int index = 0; index < sprites.Count; index++)
             {
                 var bmp = sprites[index].Image;
-                int spriteWidth = (int)bmp.SizeInPixels.Width;
-                int spriteHeight = (int)bmp.SizeInPixels.Height;
+                int spriteWidth = bmp.Width;
+                int spriteHeight = bmp.Height;
                 int projectedWidth = currentIndices.Count == 0 ? spriteWidth : currentWidth + gap + spriteWidth;
                 if (currentIndices.Count > 0 && projectedWidth > widthLimit)
                 {
@@ -451,9 +452,9 @@ namespace FramesToMMSpriteResources
                 {
                     int spriteIndex = row.indices[itemIndex];
                     var bmp = sprites[spriteIndex].Image;
-                    int yPos = yOffset + (row.height - (int)bmp.SizeInPixels.Height);
+                    int yPos = yOffset + (row.height - bmp.Height);
                     positions[spriteIndex] = new(xOffset, yPos);
-                    xOffset += (int)bmp.SizeInPixels.Width;
+                    xOffset += bmp.Width;
                     if (itemIndex < row.indices.Count - 1)
                     {
                         xOffset += gap;
@@ -470,7 +471,7 @@ namespace FramesToMMSpriteResources
         {
             int gap = gameThemeConfig.IsHd ? 2 : 1;
             if (sprites.Count == 0) return (new(0, 0), new List<IntVector2?>());
-            var widths = sprites.Select(s => (int)s.Image.SizeInPixels.Width).ToList();
+            var widths = sprites.Select(s => s.Image.Width).ToList();
             int maxWidth = widths.Max();
             int totalWidth = widths.Sum();
             var candidateWidths = new HashSet<int>() { maxWidth, totalWidth + gap * (sprites.Count - 1) };
@@ -480,7 +481,7 @@ namespace FramesToMMSpriteResources
                 prefix += widths[i];
                 candidateWidths.Add(Math.Max(maxWidth, prefix + gap * i));
             }
-          
+
             (IntVector2, List<IntVector2?>) bestLayout = default;
             (double, double, double)? bestScore = null;
 
@@ -513,59 +514,68 @@ namespace FramesToMMSpriteResources
 
 
 
-        static CanvasBitmap RemoveColorWithThreshold(CanvasBitmap src)
+        static Image RemoveColorWithThreshold(Image src)
         {
-            float normalizedTolerance = (float)Math.Clamp(subjectConfig.ColorTreshold / MaxColorDistance, 0.0, 1.0);
-            var source = (ICanvasImage)new ChromaKeyEffect
-            {
-                Source = src,
-                Color = Windows.UI.Color.FromArgb(255, parsedBackgroundColor!.Value.r, parsedBackgroundColor.Value.g, parsedBackgroundColor.Value.b),
-                Tolerance = normalizedTolerance,
-                Feather = false,
-                InvertAlpha = false
-            };
+            var bytes = src.WriteToMemory();
+            int bands = src.Bands;
+            if (bands < 4) throw new InvalidOperationException("RGBA image is required for background removal.");
 
-            if (programConfig.ReduceFileSize)
+            double thr2 = subjectConfig.ColorTreshold * subjectConfig.ColorTreshold;
+            byte tr = parsedBackgroundColor!.Value.r;
+            byte tg = parsedBackgroundColor.Value.g;
+            byte tb = parsedBackgroundColor.Value.b;
+            byte ta = parsedBackgroundColor.Value.a;
+
+            for (int i = 0; i < bytes.Length; i += bands)
             {
-                source = new PremultiplyEffect
+                int r = bytes[i + 0];
+                int g = bytes[i + 1];
+                int b = bytes[i + 2];
+                int a = bytes[i + 3];
+
+                int dr = r - tr;
+                int dg = g - tg;
+                int db = b - tb;
+                int da = a - ta;
+                long dist2 = (long)dr * dr + (long)dg * dg + (long)db * db + (long)da * da;
+
+                if (dist2 <= thr2)
                 {
-                    Source = source
-                };
+                    bytes[i + 3] = 0;
+                    if (programConfig.ReduceFileSize)
+                    {
+                        bytes[i + 0] = 0;
+                        bytes[i + 1] = 0;
+                        bytes[i + 2] = 0;
+                    }
+                }
             }
 
-            return RenderImageToTarget(source, (int)src.SizeInPixels.Width, (int)src.SizeInPixels.Height, src.Dpi);
+            return Image.NewFromMemory(bytes, src.Width, src.Height, bands, src.Format);
         }
 
-        static CanvasBitmap ResizeBitmapNearest(CanvasBitmap source, IntVector2 newSize)
+        static Image ResizeBitmapNearest(Image source, IntVector2 newSize)
         {
-            var rt = new CanvasRenderTarget(SharedCanvasDevice, newSize.X, newSize.Y, source.Dpi);
-            using (var ds = rt.CreateDrawingSession())
-            {
-                ds.DrawImage(source,
-                    new Windows.Foundation.Rect(0, 0, newSize.X, newSize.Y),
-                    source.Bounds,
-                    1.0f,
-                    CanvasImageInterpolation.NearestNeighbor);
-            }
-            return rt;
-
+            double sx = (double)newSize.X / Math.Max(1, source.Width);
+            double sy = (double)newSize.Y / Math.Max(1, source.Height);
+            return source.Resize(sx, vscale: sy, kernel: Enums.Kernel.Nearest);
         }
 
-        static (CanvasBitmap cropped, IntVector2 offset) TrimColor(CanvasBitmap src)
+        static (Image cropped, IntVector2 offset) TrimColor(Image src)
         {
-            IntVector2 size = new((int)src.SizeInPixels.Width, (int)src.SizeInPixels.Height);
-            var bytes = src.GetPixelBytes();
+            IntVector2 size = new(src.Width, src.Height);
+            var bytes = src.WriteToMemory();
+            int bands = src.Bands;
 
             if (subjectConfig.BackgroundColor == null || subjectConfig.RemoveBackground)
             {
-                // treat as alpha trimming
                 int left = size.X, top = size.Y, right = 0, bottom = 0;
                 bool any = false;
                 for (int y = 0; y < size.Y; y++)
                 {
                     for (int x = 0; x < size.X; x++)
                     {
-                        int idx = (y * size.X + x) * 4;
+                        int idx = (y * size.X + x) * bands;
                         byte a = bytes[idx + 3];
                         if (a != 0)
                         {
@@ -578,7 +588,7 @@ namespace FramesToMMSpriteResources
                     }
                 }
                 if (!any) return (src, new(0, 0));
-                right++; bottom++; // exclusive
+                right++; bottom++;
                 if (gameThemeConfig.IsHd)
                 {
                     (left, top, right, bottom) = AlignEvenBox(left, top, right, bottom, size);
@@ -588,7 +598,7 @@ namespace FramesToMMSpriteResources
             }
             else
             {
-             
+
                 double thr2 = subjectConfig.ColorTreshold * subjectConfig.ColorTreshold;
                 byte tr = parsedBackgroundColor.Value.r, tg = parsedBackgroundColor.Value.g, tb = parsedBackgroundColor.Value.b, ta = parsedBackgroundColor.Value.a;
 
@@ -600,10 +610,10 @@ namespace FramesToMMSpriteResources
                 {
                     for (int x = 0; x < size.X; x++)
                     {
-                        int idx = (y * size.X + x) * 4;
-                        int b = bytes[idx + 0];
+                        int idx = (y * size.X + x) * bands;
+                        int r = bytes[idx + 0];
                         int g = bytes[idx + 1];
-                        int r = bytes[idx + 2];
+                        int b = bytes[idx + 2];
                         int a = bytes[idx + 3];
 
                         int dr = r - tr;
@@ -662,40 +672,17 @@ namespace FramesToMMSpriteResources
             return (leftAligned, topAligned, rightAligned, bottomAligned);
         }
 
-        private static CanvasBitmap CropBitmap(CanvasBitmap src, int left, int top, int width, int height)
+        private static Image CropBitmap(Image src, int left, int top, int width, int height)
         {
-            var rt = new CanvasRenderTarget(SharedCanvasDevice, width, height, src.Dpi);
-            using (var ds = rt.CreateDrawingSession())
-            {
-                var srcRect = new Windows.Foundation.Rect(left, top, width, height);
-                ds.DrawImage(src, new Windows.Foundation.Rect(0, 0, width, height), srcRect);
-            }
-            return rt;
+            return src.ExtractArea(left, top, width, height);
         }
 
-        static CanvasBitmap EnsureEvenDimensions(CanvasBitmap src)
+        static Image EnsureEvenDimensions(Image src)
         {
-            IntVector2 size = new((int)src.SizeInPixels.Width, (int)src.SizeInPixels.Height);
+            IntVector2 size = new(src.Width, src.Height);
             IntVector2 newSize = new(size.X + (size.X % 2), size.Y + (size.Y % 2));
             if (newSize.X == size.X && newSize.Y == size.Y) return src;
-            var rt = new CanvasRenderTarget(SharedCanvasDevice, newSize.X, newSize.Y, src.Dpi);
-            using (var ds = rt.CreateDrawingSession())
-            {
-                ds.Clear(Microsoft.UI.Colors.Transparent);
-                ds.DrawImage(src, new Windows.Foundation.Rect(0, 0, size.X, size.Y));
-            }
-            return rt;
-        }
-
-        private static CanvasBitmap RenderImageToTarget(ICanvasImage image, int width, int height, float dpi)
-        {
-            var rt = new CanvasRenderTarget(SharedCanvasDevice, width, height, dpi);
-            using (var ds = rt.CreateDrawingSession())
-            {
-                ds.Clear(Microsoft.UI.Colors.Transparent);
-                ds.DrawImage(image);
-            }
-            return rt;
+            return src.Embed(0, 0, newSize.X, newSize.Y, extend: Enums.Extend.Background, background: [0, 0, 0, 0]);
         }
 
         private static int EnsureEvenValue(int v) => (v % 2 == 0) ? v : v + 1;


### PR DESCRIPTION
### Motivation
- Replace the Win2D-based image pipeline with `NetVips` to enable much faster, native image processing for large sprite batches.

### Description
- Swapped the package reference in `FramesToMMSpriteResources.csproj` from `Microsoft.Graphics.Win2D` to `NetVips` and updated imports accordingly.  
- Rewrote `Processer` (`FramesToMMSpriteResources/Processer.cs`) to use `NetVips.Image` end-to-end, replacing `CanvasBitmap`/`CanvasRenderTarget`/drawing sessions with `Image.NewFromFile`, `Image.Resize`, `Image.ExtractArea`, `Image.Insert`, `Image.Embed`, and `Image.WriteToFile`.  
- Implemented `LoadImage`, `SaveImageToFile`, `RemoveColorWithThreshold`, `ResizeBitmapNearest`, `TrimColor`, and sheet composition using NetVips memory buffers while preserving existing layout and metadata export logic.  
- Kept original sprite metadata, trimming, HD scaling and reduce-file-size behaviors; added RGBA normalization for 3-band images and small API adjustments (e.g. `await Task.CompletedTask` where needed).

### Testing
- Ran `git diff --check` which reported no problems.  
- Attempted `dotnet build FramesToMMSpriteResources/FramesToMMSpriteResources.csproj` but the environment lacks the `dotnet` SDK so build verification could not be performed.  
- Committed the changes with `git` (local commit created) and validated diffs; no automated unit tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c7c7e1008327a1e8deb34f2b755d)