### PR TITLE
Add interactive coordinate canvas to frame panel

### DIFF
--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -298,7 +298,39 @@
                             
                             <StackPanel x:Name="FrameDetailPanel" Spacing="10" Padding="20 14 20 20" MaxWidth="1000">
 
-                                <!-- A CANVAS LIKE THING HERE -->
+                                <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
+                                    <StackPanel Spacing="12">
+                                        <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
+                                        <Rectangle Style="{StaticResource GroupDividerStyle}"/>
+                                        <TextBlock Text="Drag in the area below to pan around the coordinate plane. You can also set the sprite position manually with X/Y values."
+                                                   Style="{StaticResource HelperTextStyle}"/>
+
+                                        <Grid ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <NumberBox x:Name="FrameVectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorXTextBox_ValueChanged"/>
+                                            <NumberBox x:Name="FrameVectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorYTextBox_ValueChanged"/>
+                                        </Grid>
+
+                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="8" Background="{ThemeResource LayerFillColorDefaultBrush}">
+                                            <Canvas x:Name="FrameCoordinateCanvas"
+                                                    Height="320"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Top"
+                                                    SizeChanged="FrameCoordinateCanvas_SizeChanged"
+                                                    PointerPressed="FrameCoordinateCanvas_PointerPressed"
+                                                    PointerMoved="FrameCoordinateCanvas_PointerMoved"
+                                                    PointerReleased="FrameCoordinateCanvas_PointerReleased"
+                                                    PointerExited="FrameCoordinateCanvas_PointerReleased">
+                                                <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" PointerPressed="FrameCoordinateSpriteImage_PointerPressed"/>
+                                            </Canvas>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
 
                             </StackPanel>
                             

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -224,6 +224,14 @@ namespace FramesToMMSpriteResources
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
 
+        private Vector2 _frameCanvasPan = Vector2.Zero;
+        private Vector2 _frameSpritePosition = Vector2.Zero;
+        private Vector2 _frameDragStartPointer;
+        private Vector2 _frameDragStartPan;
+        private bool _isFrameCanvasDragging;
+        private bool _isFrameSpriteDragging;
+        private bool _isUpdatingFrameVectorTextBoxes;
+
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
         {
@@ -256,6 +264,7 @@ namespace FramesToMMSpriteResources
             HeaderBreadcrumbBar.ItemClicked += BreadcrumbBar_ItemClicked;
 
             ProgramNameTextBlock.Text += GetCurrentVersion();
+            InitializeFrameCoordinatePlane();
 
         
             CheckForUpdateIfNeeded();
@@ -1445,6 +1454,154 @@ namespace FramesToMMSpriteResources
 
 
 
+        }
+
+        private void InitializeFrameCoordinatePlane()
+        {
+            _frameCanvasPan = Vector2.Zero;
+            _frameSpritePosition = Vector2.Zero;
+            _isFrameCanvasDragging = false;
+            _isFrameSpriteDragging = false;
+
+            _isUpdatingFrameVectorTextBoxes = true;
+            FrameVectorXTextBox.Value = 0;
+            FrameVectorYTextBox.Value = 0;
+            _isUpdatingFrameVectorTextBoxes = false;
+
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void UpdateFrameCoordinateVisuals()
+        {
+            if (FrameCoordinateCanvas == null)
+            {
+                return;
+            }
+
+            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
+            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
+
+            if (canvasWidth <= 0 || canvasHeight <= 0)
+            {
+                return;
+            }
+
+            double centerX = canvasWidth / 2.0;
+            double centerY = canvasHeight / 2.0;
+
+            double axisX = centerX + _frameCanvasPan.X;
+            double axisY = centerY + _frameCanvasPan.Y;
+
+            FrameXAxis.Width = canvasWidth;
+            Canvas.SetLeft(FrameXAxis, 0);
+            Canvas.SetTop(FrameXAxis, axisY - (FrameXAxis.Height / 2.0));
+
+            FrameYAxis.Height = canvasHeight;
+            Canvas.SetLeft(FrameYAxis, axisX - (FrameYAxis.Width / 2.0));
+            Canvas.SetTop(FrameYAxis, 0);
+
+            double spriteCanvasX = axisX + _frameSpritePosition.X;
+            double spriteCanvasY = axisY - _frameSpritePosition.Y;
+
+            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (FrameCoordinateSpriteImage.Width / 2.0));
+            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (FrameCoordinateSpriteImage.Height / 2.0));
+        }
+
+        private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameCoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (_isFrameSpriteDragging)
+            {
+                return;
+            }
+
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+            _frameDragStartPan = _frameCanvasPan;
+            _isFrameCanvasDragging = true;
+
+            FrameCoordinateCanvas.CapturePointer(e.Pointer);
+        }
+
+        private void FrameCoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
+
+            if (_isFrameSpriteDragging)
+            {
+                double canvasWidth = FrameCoordinateCanvas.ActualWidth;
+                double canvasHeight = FrameCoordinateCanvas.ActualHeight;
+
+                double centerX = canvasWidth / 2.0;
+                double centerY = canvasHeight / 2.0;
+                double axisX = centerX + _frameCanvasPan.X;
+                double axisY = centerY + _frameCanvasPan.Y;
+
+                _frameSpritePosition = new Vector2(
+                    currentPosition.X - (float)axisX,
+                    (float)axisY - currentPosition.Y
+                );
+
+                SyncFrameVectorInputsWithSpritePosition();
+                UpdateFrameCoordinateVisuals();
+                return;
+            }
+
+            if (_isFrameCanvasDragging)
+            {
+                _frameCanvasPan = _frameDragStartPan + (currentPosition - _frameDragStartPointer);
+                UpdateFrameCoordinateVisuals();
+            }
+        }
+
+        private void FrameCoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            _isFrameCanvasDragging = false;
+            _isFrameSpriteDragging = false;
+            FrameCoordinateCanvas.ReleasePointerCapture(e.Pointer);
+        }
+
+        private void FrameCoordinateSpriteImage_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            _isFrameSpriteDragging = true;
+            _isFrameCanvasDragging = false;
+            FrameCoordinateCanvas.CapturePointer(e.Pointer);
+            e.Handled = true;
+        }
+
+        private void SyncFrameVectorInputsWithSpritePosition()
+        {
+            _isUpdatingFrameVectorTextBoxes = true;
+            FrameVectorXTextBox.Value = (int)Math.Round(_frameSpritePosition.X);
+            FrameVectorYTextBox.Value = (int)Math.Round(_frameSpritePosition.Y);
+            _isUpdatingFrameVectorTextBoxes = false;
+        }
+
+        private void FrameVectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isUpdatingFrameVectorTextBoxes)
+            {
+                return;
+            }
+
+            _frameSpritePosition = new Vector2(double.IsNaN(sender.Value) ? 0 : (float)sender.Value, _frameSpritePosition.Y);
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameVectorYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isUpdatingFrameVectorTextBoxes)
+            {
+                return;
+            }
+
+            _frameSpritePosition = new Vector2(_frameSpritePosition.X, double.IsNaN(sender.Value) ? 0 : (float)sender.Value);
+            UpdateFrameCoordinateVisuals();
         }
 
         private void DetachAllPanelEvents()


### PR DESCRIPTION
### Motivation
- Provide a simple visual coordinate plane in the Frame panel so users can pan/inspect coordinates and position a sprite marker when editing frame offsets.
- Allow both direct manipulation (dragging the marker) and manual setting of Vector2 X/Y so offsets can be adjusted interactively.

### Description
- Replaced the frame panel placeholder in `MainWindow.xaml` with a card containing `NumberBox` inputs for `FrameVectorXTextBox`/`FrameVectorYTextBox`, a bordered `Canvas` (`FrameCoordinateCanvas`), two axis `Rectangle`s, and an image marker (`FrameCoordinateSpriteImage`).
- Added state fields to `MainWindow` for pan/marker position and drag state, initialized via `InitializeFrameCoordinatePlane()` called from the constructor.
- Implemented `UpdateFrameCoordinateVisuals()` to render axes and position the marker, plus event handlers `FrameCoordinateCanvas_SizeChanged`, `FrameCoordinateCanvas_PointerPressed`, `FrameCoordinateCanvas_PointerMoved`, `FrameCoordinateCanvas_PointerReleased`, and `FrameCoordinateSpriteImage_PointerPressed` to support panning and marker dragging.
- Implemented two-way sync between the marker position and the `NumberBox` inputs via `SyncFrameVectorInputsWithSpritePosition()` and `FrameVectorXTextBox_ValueChanged` / `FrameVectorYTextBox_ValueChanged` so manual edits reposition the marker.

### Testing
- Attempted to build with `dotnet build FramesToMMSpriteResources.slnx`, which failed in this environment because `dotnet` is not installed (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7c93451c8327b685b9c7f74633c1)