### PR TITLE
Add interactive frame coordinate editor with pan/drag canvas and X/Y controls

### DIFF
--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -298,7 +298,39 @@
                             
                             <StackPanel x:Name="FrameDetailPanel" Spacing="10" Padding="20 14 20 20" MaxWidth="1000">
 
-                                <!-- A CANVAS LIKE THING HERE -->
+                                <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
+                                    <StackPanel Spacing="12">
+                                        <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
+                                        <Rectangle Style="{StaticResource GroupDividerStyle}"/>
+                                        <TextBlock Text="Drag in the area below to pan around the coordinate plane. You can also set the sprite position manually with X/Y values."
+                                                   Style="{StaticResource HelperTextStyle}"/>
+
+                                        <Grid ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <NumberBox x:Name="FrameVectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorXTextBox_ValueChanged"/>
+                                            <NumberBox x:Name="FrameVectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorYTextBox_ValueChanged"/>
+                                        </Grid>
+
+                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="8" Background="{ThemeResource LayerFillColorDefaultBrush}">
+                                            <Canvas x:Name="FrameCoordinateCanvas"
+                                                    Height="320"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Top"
+                                                    SizeChanged="FrameCoordinateCanvas_SizeChanged"
+                                                    PointerPressed="FrameCoordinateCanvas_PointerPressed"
+                                                    PointerMoved="FrameCoordinateCanvas_PointerMoved"
+                                                    PointerReleased="FrameCoordinateCanvas_PointerReleased"
+                                                    PointerExited="FrameCoordinateCanvas_PointerReleased">
+                                                <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png"/>
+                                            </Canvas>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
 
                             </StackPanel>
                             

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -224,6 +224,12 @@ namespace FramesToMMSpriteResources
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
 
+        private Vector2 _frameCanvasPan = Vector2.Zero;
+        private Vector2 _frameSpritePosition = Vector2.Zero;
+        private Vector2 _frameDragStartPointer;
+        private Vector2 _frameDragStartPan;
+        private bool _isFrameCanvasDragging;
+
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
         {
@@ -256,6 +262,7 @@ namespace FramesToMMSpriteResources
             HeaderBreadcrumbBar.ItemClicked += BreadcrumbBar_ItemClicked;
 
             ProgramNameTextBlock.Text += GetCurrentVersion();
+            InitializeFrameCoordinatePlane();
 
         
             CheckForUpdateIfNeeded();
@@ -1445,6 +1452,98 @@ namespace FramesToMMSpriteResources
 
 
 
+        }
+
+        private void InitializeFrameCoordinatePlane()
+        {
+            _frameCanvasPan = Vector2.Zero;
+            _frameSpritePosition = Vector2.Zero;
+            _isFrameCanvasDragging = false;
+            FrameVectorXTextBox.Value = 0;
+            FrameVectorYTextBox.Value = 0;
+
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void UpdateFrameCoordinateVisuals()
+        {
+            if (FrameCoordinateCanvas == null)
+            {
+                return;
+            }
+
+            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
+            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
+
+            if (canvasWidth <= 0 || canvasHeight <= 0)
+            {
+                return;
+            }
+
+            double centerX = canvasWidth / 2.0;
+            double centerY = canvasHeight / 2.0;
+
+            double axisX = centerX + _frameCanvasPan.X;
+            double axisY = centerY + _frameCanvasPan.Y;
+
+            FrameXAxis.Width = canvasWidth;
+            Canvas.SetLeft(FrameXAxis, 0);
+            Canvas.SetTop(FrameXAxis, axisY - (FrameXAxis.Height / 2.0));
+
+            FrameYAxis.Height = canvasHeight;
+            Canvas.SetLeft(FrameYAxis, axisX - (FrameYAxis.Width / 2.0));
+            Canvas.SetTop(FrameYAxis, 0);
+
+            double spriteCanvasX = axisX + _frameSpritePosition.X;
+            double spriteCanvasY = axisY - _frameSpritePosition.Y;
+
+            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (FrameCoordinateSpriteImage.Width / 2.0));
+            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (FrameCoordinateSpriteImage.Height / 2.0));
+        }
+
+        private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameCoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+            _frameDragStartPan = _frameCanvasPan;
+            _isFrameCanvasDragging = true;
+
+            FrameCoordinateCanvas.CapturePointer(e.Pointer);
+        }
+
+        private void FrameCoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
+
+            if (_isFrameCanvasDragging)
+            {
+                _frameCanvasPan = _frameDragStartPan + (currentPosition - _frameDragStartPointer);
+                UpdateFrameCoordinateVisuals();
+            }
+        }
+
+        private void FrameCoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            _isFrameCanvasDragging = false;
+            FrameCoordinateCanvas.ReleasePointerCapture(e.Pointer);
+        }
+
+        private void FrameVectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            _frameSpritePosition = new Vector2(double.IsNaN(sender.Value) ? 0 : (float)sender.Value, _frameSpritePosition.Y);
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameVectorYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            _frameSpritePosition = new Vector2(_frameSpritePosition.X, double.IsNaN(sender.Value) ? 0 : (float)sender.Value);
+            UpdateFrameCoordinateVisuals();
         }
 
         private void DetachAllPanelEvents()


### PR DESCRIPTION
### Motivation
- Provide an interactive coordinate plane for editing frame sprite positions so users can pan/drag and set sprite offsets numerically. 
- Improve UX for positioning frames when preparing sprite resources by exposing a visual canvas and numeric inputs for precise adjustments.

### Description
- Added UI in `MainWindow.xaml` for a new "Frame coordinates" card including `NumberBox` controls `FrameVectorXTextBox` and `FrameVectorYTextBox`, and a `Canvas` named `FrameCoordinateCanvas` with axis rectangles and `FrameCoordinateSpriteImage` for the sprite marker. 
- Implemented state and behavior in `MainWindow.xaml.cs`: added fields `_frameCanvasPan`, `_frameSpritePosition`, drag tracking variables, and `_isFrameCanvasDragging`. 
- Added initialization via `InitializeFrameCoordinatePlane()` called from the constructor and an `UpdateFrameCoordinateVisuals()` helper to keep axes and sprite marker positioned. 
- Implemented pointer and size event handlers `FrameCoordinateCanvas_SizeChanged`, `FrameCoordinateCanvas_PointerPressed`, `FrameCoordinateCanvas_PointerMoved`, `FrameCoordinateCanvas_PointerReleased` and `FrameVectorXTextBox_ValueChanged` / `FrameVectorYTextBox_ValueChanged` to support panning, releasing, and numeric updates.

### Testing
- Performed an automated project build with `dotnet build` which completed successfully. 
- There were no project unit tests affected by these UI additions so no automated unit test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7c93451c8327b685b9c7f74633c1)