### PR TITLE
Add interactive frame coordinate canvas with pan/zoom and editable sprite position

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -1,0 +1,54 @@
+<UserControl
+    x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
+        <StackPanel Spacing="12">
+            <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
+            <Rectangle Style="{StaticResource GroupDividerStyle}"/>
+            <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
+                       Style="{StaticResource HelperTextStyle}"/>
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="ZoomTextBlock" Grid.Column="0" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" Click="CenterOriginButton_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon Glyph="&#xE777;" FontSize="12"/>
+                        <TextBlock Text="Center origin"/>
+                    </StackPanel>
+                </Button>
+            </Grid>
+
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <NumberBox x:Name="VectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="VectorXTextBox_ValueChanged"/>
+                <NumberBox x:Name="VectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="VectorYTextBox_ValueChanged"/>
+            </Grid>
+
+            <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
+                <Canvas x:Name="CoordinateCanvas"
+                        Height="320"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Top"
+                        Background="Transparent"
+                        SizeChanged="CoordinateCanvas_SizeChanged"
+                        PointerPressed="CoordinateCanvas_PointerPressed"
+                        PointerMoved="CoordinateCanvas_PointerMoved"
+                        PointerReleased="CoordinateCanvas_PointerReleased"
+                        PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
+                        PointerExited="CoordinateCanvas_PointerReleased">
+                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="Fill"/>
+                    <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                    <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                    <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False"/>
+                </Canvas>
+            </Border>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,0 +1,279 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System;
+using System.IO;
+using System.Numerics;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace FramesToMMSpriteResources;
+
+public sealed partial class FrameCoordinateEditor : UserControl
+{
+    private Vector2 _pan = Vector2.Zero;
+    private Vector2 _spritePosition = Vector2.Zero;
+    private Vector2 _dragStartPointer;
+    private Vector2 _dragStartPan;
+    private bool _isDragging;
+    private float _zoom = 1.0f;
+    private const float MinZoom = 0.2f;
+    private const float MaxZoom = 14.0f;
+    private const double SpriteBaseSize = 48.0;
+
+    private WriteableBitmap? _checkerBitmap;
+    private byte[]? _checkerPixels;
+
+    private byte[]? _spriteSourcePixels;
+    private int _spriteSourceWidth;
+    private int _spriteSourceHeight;
+    private int _spriteRenderedSize = -1;
+    private WriteableBitmap? _spriteBitmap;
+
+    public FrameCoordinateEditor()
+    {
+        this.InitializeComponent();
+        VectorXTextBox.Value = 0;
+        VectorYTextBox.Value = 0;
+        _ = SetSpriteImageUriAsync("ms-appx:///Assets/icon.png");
+        UpdateVisuals();
+    }
+
+    public Vector2 SpritePosition
+    {
+        get => _spritePosition;
+        set
+        {
+            _spritePosition = value;
+            VectorXTextBox.Value = value.X;
+            VectorYTextBox.Value = value.Y;
+            UpdateVisuals();
+        }
+    }
+
+    public event Action<Vector2>? SpritePositionChanged;
+
+    public async System.Threading.Tasks.Task SetSpriteImageUriAsync(string uri)
+    {
+        StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
+        using IRandomAccessStream stream = await file.OpenReadAsync();
+        BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
+        PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            new BitmapTransform(),
+            ExifOrientationMode.IgnoreExifOrientation,
+            ColorManagementMode.DoNotColorManage);
+
+        _spriteSourcePixels = pixelData.DetachPixelData();
+        _spriteSourceWidth = (int)decoder.PixelWidth;
+        _spriteSourceHeight = (int)decoder.PixelHeight;
+        _spriteRenderedSize = -1;
+        UpdateVisuals();
+    }
+
+    private void UpdateVisuals()
+    {
+        double canvasWidth = CoordinateCanvas.ActualWidth;
+        double canvasHeight = CoordinateCanvas.ActualHeight;
+        if (canvasWidth <= 0 || canvasHeight <= 0)
+        {
+            return;
+        }
+
+        double centerX = canvasWidth / 2.0;
+        double centerY = canvasHeight / 2.0;
+        double axisX = centerX + _pan.X;
+        double axisY = centerY + _pan.Y;
+
+        UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
+
+        XAxis.Width = canvasWidth;
+        Canvas.SetLeft(XAxis, 0);
+        Canvas.SetTop(XAxis, axisY - (XAxis.Height / 2.0));
+
+        YAxis.Height = canvasHeight;
+        Canvas.SetLeft(YAxis, axisX - (YAxis.Width / 2.0));
+        Canvas.SetTop(YAxis, 0);
+
+        double spriteSize = SpriteBaseSize * _zoom;
+        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteSize)));
+
+        double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
+        double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
+        SpriteImage.Width = spriteSize;
+        SpriteImage.Height = spriteSize;
+        Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteSize / 2.0));
+        Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteSize / 2.0));
+
+        ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
+    }
+
+    private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
+    {
+        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
+        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
+        int byteCount = pixelWidth * pixelHeight * 4;
+
+        if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
+        {
+            _checkerBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
+            _checkerPixels = new byte[byteCount];
+            CheckerboardImage.Source = _checkerBitmap;
+        }
+        else if (_checkerPixels == null || _checkerPixels.Length != byteCount)
+        {
+            _checkerPixels = new byte[byteCount];
+        }
+
+        double tileSize = 4.0 * _zoom;
+        int idx = 0;
+        for (int y = 0; y < pixelHeight; y++)
+        {
+            int tileY = (int)Math.Floor((axisY - y) / tileSize);
+            for (int x = 0; x < pixelWidth; x++)
+            {
+                int tileX = (int)Math.Floor((x - axisX) / tileSize);
+                byte color = ((tileX + tileY) & 1) == 0 ? (byte)238 : (byte)206;
+
+                _checkerPixels![idx++] = color;
+                _checkerPixels[idx++] = color;
+                _checkerPixels[idx++] = color;
+                _checkerPixels[idx++] = 255;
+            }
+        }
+
+        using Stream stream = _checkerBitmap!.PixelBuffer.AsStream();
+        stream.Position = 0;
+        stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
+        _checkerBitmap.Invalidate();
+    }
+
+    private void UpdateSpriteBitmap(int targetSize)
+    {
+        if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
+        {
+            return;
+        }
+
+        if (_spriteBitmap != null && _spriteRenderedSize == targetSize)
+        {
+            SpriteImage.Source = _spriteBitmap;
+            return;
+        }
+
+        _spriteBitmap = new WriteableBitmap(targetSize, targetSize);
+        byte[] scaled = new byte[targetSize * targetSize * 4];
+
+        for (int y = 0; y < targetSize; y++)
+        {
+            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetSize) * _spriteSourceHeight));
+            for (int x = 0; x < targetSize; x++)
+            {
+                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetSize) * _spriteSourceWidth));
+                int src = ((sy * _spriteSourceWidth) + sx) * 4;
+                int dst = ((y * targetSize) + x) * 4;
+                scaled[dst] = _spriteSourcePixels[src];
+                scaled[dst + 1] = _spriteSourcePixels[src + 1];
+                scaled[dst + 2] = _spriteSourcePixels[src + 2];
+                scaled[dst + 3] = _spriteSourcePixels[src + 3];
+            }
+        }
+
+        using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
+        stream.Position = 0;
+        stream.Write(scaled, 0, scaled.Length);
+        _spriteBitmap.Invalidate();
+
+        SpriteImage.Source = _spriteBitmap;
+        _spriteRenderedSize = targetSize;
+    }
+
+    private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e) => UpdateVisuals();
+
+    private void CoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(CoordinateCanvas);
+        _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        _dragStartPan = _pan;
+        _isDragging = true;
+        CoordinateCanvas.CapturePointer(e.Pointer);
+    }
+
+    private void CoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(CoordinateCanvas);
+        var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        _pan = _dragStartPan + (currentPosition - _dragStartPointer);
+        UpdateVisuals();
+    }
+
+    private void CoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+        CoordinateCanvas.ReleasePointerCapture(e.Pointer);
+    }
+
+    private void CoordinateCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(CoordinateCanvas);
+        int wheelDelta = point.Properties.MouseWheelDelta;
+        if (wheelDelta == 0)
+        {
+            return;
+        }
+
+        float oldZoom = _zoom;
+        float zoomMultiplier = wheelDelta > 0 ? 1.1f : 0.9f;
+        float newZoom = Math.Clamp(oldZoom * zoomMultiplier, MinZoom, MaxZoom);
+        if (Math.Abs(newZoom - oldZoom) < 0.0001f)
+        {
+            return;
+        }
+
+        double centerX = CoordinateCanvas.ActualWidth / 2.0;
+        double centerY = CoordinateCanvas.ActualHeight / 2.0;
+        double oldAxisX = centerX + _pan.X;
+        double oldAxisY = centerY + _pan.Y;
+
+        double worldX = (point.Position.X - oldAxisX) / oldZoom;
+        double worldY = (oldAxisY - point.Position.Y) / oldZoom;
+
+        _zoom = newZoom;
+
+        double newAxisX = point.Position.X - (worldX * newZoom);
+        double newAxisY = point.Position.Y + (worldY * newZoom);
+
+        _pan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
+        UpdateVisuals();
+        e.Handled = true;
+    }
+
+    private void CenterOriginButton_Click(object sender, RoutedEventArgs e)
+    {
+        _pan = Vector2.Zero;
+        UpdateVisuals();
+    }
+
+    private void VectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        _spritePosition = new Vector2(double.IsNaN(sender.Value) ? 0 : (float)sender.Value, _spritePosition.Y);
+        UpdateVisuals();
+        SpritePositionChanged?.Invoke(_spritePosition);
+    }
+
+    private void VectorYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        _spritePosition = new Vector2(_spritePosition.X, double.IsNaN(sender.Value) ? 0 : (float)sender.Value);
+        UpdateVisuals();
+        SpritePositionChanged?.Invoke(_spritePosition);
+    }
+}

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -304,7 +304,19 @@
                                         <Rectangle Style="{StaticResource GroupDividerStyle}"/>
                                         <TextBlock Text="Drag in the area below to pan around the coordinate plane. You can also set the sprite position manually with X/Y values."
                                                    Style="{StaticResource HelperTextStyle}"/>
-                                        <TextBlock x:Name="FrameZoomTextBlock" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}"/>
+                                        <Grid ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock x:Name="FrameZoomTextBlock" Grid.Column="0" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}" VerticalAlignment="Center"/>
+                                            <Button Grid.Column="1" Click="CenterFrameOriginButton_Click">
+                                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                                    <FontIcon Glyph="&#xE777;" FontSize="12"/>
+                                                    <TextBlock Text="Center origin"/>
+                                                </StackPanel>
+                                            </Button>
+                                        </Grid>
 
                                         <Grid ColumnSpacing="8">
                                             <Grid.ColumnDefinitions>

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -320,6 +320,7 @@
                                                     Height="320"
                                                     HorizontalAlignment="Stretch"
                                                     VerticalAlignment="Top"
+                                                    Background="Transparent"
                                                     SizeChanged="FrameCoordinateCanvas_SizeChanged"
                                                     PointerPressed="FrameCoordinateCanvas_PointerPressed"
                                                     PointerMoved="FrameCoordinateCanvas_PointerMoved"

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -327,7 +327,7 @@
                                             <NumberBox x:Name="FrameVectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorYTextBox_ValueChanged"/>
                                         </Grid>
 
-                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="8" Background="{ThemeResource LayerFillColorDefaultBrush}">
+                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
                                             <Canvas x:Name="FrameCoordinateCanvas"
                                                     Height="320"
                                                     HorizontalAlignment="Stretch"

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -328,7 +328,7 @@
                                                     PointerExited="FrameCoordinateCanvas_PointerReleased">
                                                 <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                                                 <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False"/>
                                             </Canvas>
                                         </Border>
                                     </StackPanel>

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -342,7 +342,7 @@
                                                 <Canvas x:Name="FrameCheckerboardCanvas" IsHitTestVisible="False"/>
                                                 <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                                                 <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False" BitmapInterpolationMode="NearestNeighbor"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False"/>
                                             </Canvas>
                                         </Border>
                                     </StackPanel>

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -298,55 +298,7 @@
                             
                             <StackPanel x:Name="FrameDetailPanel" Spacing="10" Padding="20 14 20 20" MaxWidth="1000">
 
-                                <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
-                                    <StackPanel Spacing="12">
-                                        <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
-                                        <Rectangle Style="{StaticResource GroupDividerStyle}"/>
-                                        <TextBlock Text="Drag in the area below to pan around the coordinate plane. You can also set the sprite position manually with X/Y values."
-                                                   Style="{StaticResource HelperTextStyle}"/>
-                                        <Grid ColumnSpacing="8">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock x:Name="FrameZoomTextBlock" Grid.Column="0" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}" VerticalAlignment="Center"/>
-                                            <Button Grid.Column="1" Click="CenterFrameOriginButton_Click">
-                                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                                    <FontIcon Glyph="&#xE777;" FontSize="12"/>
-                                                    <TextBlock Text="Center origin"/>
-                                                </StackPanel>
-                                            </Button>
-                                        </Grid>
-
-                                        <Grid ColumnSpacing="8">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="*"/>
-                                            </Grid.ColumnDefinitions>
-                                            <NumberBox x:Name="FrameVectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorXTextBox_ValueChanged"/>
-                                            <NumberBox x:Name="FrameVectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorYTextBox_ValueChanged"/>
-                                        </Grid>
-
-                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
-                                            <Canvas x:Name="FrameCoordinateCanvas"
-                                                    Height="320"
-                                                    HorizontalAlignment="Stretch"
-                                                    VerticalAlignment="Top"
-                                                    Background="Transparent"
-                                                    SizeChanged="FrameCoordinateCanvas_SizeChanged"
-                                                    PointerPressed="FrameCoordinateCanvas_PointerPressed"
-                                                    PointerMoved="FrameCoordinateCanvas_PointerMoved"
-                                                    PointerReleased="FrameCoordinateCanvas_PointerReleased"
-                                                    PointerWheelChanged="FrameCoordinateCanvas_PointerWheelChanged"
-                                                    PointerExited="FrameCoordinateCanvas_PointerReleased">
-                                                <Image x:Name="FrameCheckerboardImage" IsHitTestVisible="False" Stretch="Fill"/>
-                                                <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                                                <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False"/>
-                                            </Canvas>
-                                        </Border>
-                                    </StackPanel>
-                                </Border>
+                                <local:FrameCoordinateEditor x:Name="FrameCoordinateEditorControl"/>
 
                             </StackPanel>
                             

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -298,7 +298,41 @@
                             
                             <StackPanel x:Name="FrameDetailPanel" Spacing="10" Padding="20 14 20 20" MaxWidth="1000">
 
-                                <!-- A CANVAS LIKE THING HERE -->
+                                <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
+                                    <StackPanel Spacing="12">
+                                        <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
+                                        <Rectangle Style="{StaticResource GroupDividerStyle}"/>
+                                        <TextBlock Text="Drag in the area below to pan around the coordinate plane. You can also set the sprite position manually with X/Y values."
+                                                   Style="{StaticResource HelperTextStyle}"/>
+                                        <TextBlock x:Name="FrameZoomTextBlock" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}"/>
+
+                                        <Grid ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <NumberBox x:Name="FrameVectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorXTextBox_ValueChanged"/>
+                                            <NumberBox x:Name="FrameVectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="FrameVectorYTextBox_ValueChanged"/>
+                                        </Grid>
+
+                                        <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="8" Background="{ThemeResource LayerFillColorDefaultBrush}">
+                                            <Canvas x:Name="FrameCoordinateCanvas"
+                                                    Height="320"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Top"
+                                                    SizeChanged="FrameCoordinateCanvas_SizeChanged"
+                                                    PointerPressed="FrameCoordinateCanvas_PointerPressed"
+                                                    PointerMoved="FrameCoordinateCanvas_PointerMoved"
+                                                    PointerReleased="FrameCoordinateCanvas_PointerReleased"
+                                                    PointerWheelChanged="FrameCoordinateCanvas_PointerWheelChanged"
+                                                    PointerExited="FrameCoordinateCanvas_PointerReleased">
+                                                <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png"/>
+                                            </Canvas>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
 
                             </StackPanel>
                             

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -339,7 +339,7 @@
                                                     PointerReleased="FrameCoordinateCanvas_PointerReleased"
                                                     PointerWheelChanged="FrameCoordinateCanvas_PointerWheelChanged"
                                                     PointerExited="FrameCoordinateCanvas_PointerReleased">
-                                                <Canvas x:Name="FrameCheckerboardCanvas" IsHitTestVisible="False"/>
+                                                <Image x:Name="FrameCheckerboardImage" IsHitTestVisible="False" Stretch="Fill"/>
                                                 <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                                                 <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                                                 <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False"/>

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -339,9 +339,10 @@
                                                     PointerReleased="FrameCoordinateCanvas_PointerReleased"
                                                     PointerWheelChanged="FrameCoordinateCanvas_PointerWheelChanged"
                                                     PointerExited="FrameCoordinateCanvas_PointerReleased">
+                                                <Canvas x:Name="FrameCheckerboardCanvas" IsHitTestVisible="False"/>
                                                 <Rectangle x:Name="FrameXAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                                                 <Rectangle x:Name="FrameYAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False"/>
+                                                <Image x:Name="FrameCoordinateSpriteImage" Width="48" Height="48" Source="Assets/icon.png" IsHitTestVisible="False" BitmapInterpolationMode="NearestNeighbor"/>
                                             </Canvas>
                                         </Border>
                                     </StackPanel>

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -8,7 +8,6 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
-using Microsoft.UI.Xaml.Shapes;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -26,6 +25,7 @@ using Windows.ApplicationModel;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage.Pickers;
+using Windows.UI;
 using Windows.UI.Composition;
 
 namespace FramesToMMSpriteResources
@@ -1467,6 +1467,7 @@ namespace FramesToMMSpriteResources
             _frameSpritePosition = Vector2.Zero;
             _isFrameCanvasDragging = false;
             _frameCanvasZoom = 1.0f;
+            RenderOptions.SetBitmapInterpolationMode(FrameCoordinateSpriteImage, BitmapInterpolationMode.NearestNeighbor);
             FrameVectorXTextBox.Value = 0;
             FrameVectorYTextBox.Value = 0;
 
@@ -1538,7 +1539,7 @@ namespace FramesToMMSpriteResources
             {
                 for (int tileX = minTileX; tileX <= maxTileX; tileX++)
                 {
-                    var tile = new Rectangle
+                    var tile = new Microsoft.UI.Xaml.Shapes.Rectangle
                     {
                         Width = tileSize,
                         Height = tileSize,

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -17,6 +18,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -25,7 +27,6 @@ using Windows.ApplicationModel;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage.Pickers;
-using Windows.UI;
 using Windows.UI.Composition;
 
 namespace FramesToMMSpriteResources
@@ -234,8 +235,8 @@ namespace FramesToMMSpriteResources
         private const float FrameCanvasMinZoom = 0.2f;
         private const float FrameCanvasMaxZoom = 8.0f;
         private const double FrameSpriteBaseSize = 48.0;
-        private readonly SolidColorBrush _frameCheckerLightBrush = new(Color.FromArgb(255, 238, 238, 238));
-        private readonly SolidColorBrush _frameCheckerDarkBrush = new(Color.FromArgb(255, 206, 206, 206));
+        private WriteableBitmap? _frameCheckerBitmap;
+        private byte[]? _frameCheckerPixels;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -1519,50 +1520,53 @@ namespace FramesToMMSpriteResources
 
         private void UpdateFrameCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
         {
-            FrameCheckerboardCanvas.Width = canvasWidth;
-            FrameCheckerboardCanvas.Height = canvasHeight;
-            FrameCheckerboardCanvas.Children.Clear();
+            int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
+            int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
+            int pixelCount = pixelWidth * pixelHeight;
+            int byteCount = pixelCount * 4;
 
-            double baseTileSize = 4.0 * _frameCanvasZoom;
-            if (baseTileSize <= 0)
+            if (_frameCheckerBitmap == null || _frameCheckerBitmap.PixelWidth != pixelWidth || _frameCheckerBitmap.PixelHeight != pixelHeight)
+            {
+                _frameCheckerBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
+                _frameCheckerPixels = new byte[byteCount];
+                FrameCheckerboardImage.Source = _frameCheckerBitmap;
+            }
+            else if (_frameCheckerPixels == null || _frameCheckerPixels.Length != byteCount)
+            {
+                _frameCheckerPixels = new byte[byteCount];
+            }
+
+            double tileSize = 4.0 * _frameCanvasZoom;
+            if (tileSize <= 0.0001)
             {
                 return;
             }
 
-            int stride = 1;
-            double tileSize = baseTileSize;
+            const byte light = 238;
+            const byte dark = 206;
+            int idx = 0;
 
-            int estimatedColumns = (int)Math.Ceiling(canvasWidth / tileSize) + 2;
-            int estimatedRows = (int)Math.Ceiling(canvasHeight / tileSize) + 2;
-            while ((estimatedColumns * estimatedRows) > 6000)
+            for (int y = 0; y < pixelHeight; y++)
             {
-                stride *= 2;
-                tileSize = baseTileSize * stride;
-                estimatedColumns = (int)Math.Ceiling(canvasWidth / tileSize) + 2;
-                estimatedRows = (int)Math.Ceiling(canvasHeight / tileSize) + 2;
-            }
-
-            int minTileX = (int)Math.Floor((-axisX) / baseTileSize) - stride;
-            int maxTileX = (int)Math.Ceiling((canvasWidth - axisX) / baseTileSize) + stride;
-            int minTileY = (int)Math.Floor((axisY - canvasHeight) / baseTileSize) - stride;
-            int maxTileY = (int)Math.Ceiling(axisY / baseTileSize) + stride;
-
-            for (int tileY = minTileY; tileY <= maxTileY; tileY += stride)
-            {
-                for (int tileX = minTileX; tileX <= maxTileX; tileX += stride)
+                int tileY = (int)Math.Floor((axisY - y) / tileSize);
+                for (int x = 0; x < pixelWidth; x++)
                 {
-                    var tile = new Microsoft.UI.Xaml.Shapes.Rectangle
-                    {
-                        Width = tileSize,
-                        Height = tileSize,
-                        Fill = (((tileX / stride) + (tileY / stride)) & 1) == 0 ? _frameCheckerLightBrush : _frameCheckerDarkBrush
-                    };
+                    int tileX = (int)Math.Floor((x - axisX) / tileSize);
+                    byte color = ((tileX + tileY) & 1) == 0 ? light : dark;
 
-                    Canvas.SetLeft(tile, axisX + (tileX * baseTileSize));
-                    Canvas.SetTop(tile, axisY - ((tileY + stride) * baseTileSize));
-                    FrameCheckerboardCanvas.Children.Add(tile);
+                    _frameCheckerPixels![idx++] = color;
+                    _frameCheckerPixels[idx++] = color;
+                    _frameCheckerPixels[idx++] = color;
+                    _frameCheckerPixels[idx++] = 255;
                 }
             }
+
+            using (Stream stream = _frameCheckerBitmap!.PixelBuffer.AsStream())
+            {
+                stream.Position = 0;
+                stream.Write(_frameCheckerPixels!, 0, _frameCheckerPixels!.Length);
+            }
+            _frameCheckerBitmap.Invalidate();
         }
 
         private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Shapes;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -233,7 +234,8 @@ namespace FramesToMMSpriteResources
         private const float FrameCanvasMinZoom = 0.2f;
         private const float FrameCanvasMaxZoom = 8.0f;
         private const double FrameSpriteBaseSize = 48.0;
-        private const double FrameSpriteMinSize = 14.0;
+        private readonly SolidColorBrush _frameCheckerLightBrush = new(Color.FromArgb(255, 238, 238, 238));
+        private readonly SolidColorBrush _frameCheckerDarkBrush = new(Color.FromArgb(255, 206, 206, 206));
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -1492,6 +1494,8 @@ namespace FramesToMMSpriteResources
             double axisX = centerX + _frameCanvasPan.X;
             double axisY = centerY + _frameCanvasPan.Y;
 
+            UpdateFrameCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
+
             FrameXAxis.Width = canvasWidth;
             Canvas.SetLeft(FrameXAxis, 0);
             Canvas.SetTop(FrameXAxis, axisY - (FrameXAxis.Height / 2.0));
@@ -1503,7 +1507,7 @@ namespace FramesToMMSpriteResources
             double spriteCanvasX = axisX + (_frameSpritePosition.X * _frameCanvasZoom);
             double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
 
-            double spriteSize = Math.Max(FrameSpriteBaseSize * _frameCanvasZoom, FrameSpriteMinSize);
+            double spriteSize = FrameSpriteBaseSize * _frameCanvasZoom;
             FrameCoordinateSpriteImage.Width = spriteSize;
             FrameCoordinateSpriteImage.Height = spriteSize;
 
@@ -1511,6 +1515,41 @@ namespace FramesToMMSpriteResources
             Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (spriteSize / 2.0));
 
             FrameZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_frameCanvasZoom * 100)}%";
+        }
+
+        private void UpdateFrameCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
+        {
+            FrameCheckerboardCanvas.Width = canvasWidth;
+            FrameCheckerboardCanvas.Height = canvasHeight;
+            FrameCheckerboardCanvas.Children.Clear();
+
+            double tileSize = 4.0 * _frameCanvasZoom;
+            if (tileSize <= 0)
+            {
+                return;
+            }
+
+            int minTileX = (int)Math.Floor((-axisX) / tileSize) - 1;
+            int maxTileX = (int)Math.Ceiling((canvasWidth - axisX) / tileSize) + 1;
+            int minTileY = (int)Math.Floor((axisY - canvasHeight) / tileSize) - 1;
+            int maxTileY = (int)Math.Ceiling(axisY / tileSize) + 1;
+
+            for (int tileY = minTileY; tileY <= maxTileY; tileY++)
+            {
+                for (int tileX = minTileX; tileX <= maxTileX; tileX++)
+                {
+                    var tile = new Rectangle
+                    {
+                        Width = tileSize,
+                        Height = tileSize,
+                        Fill = ((tileX + tileY) & 1) == 0 ? _frameCheckerLightBrush : _frameCheckerDarkBrush
+                    };
+
+                    Canvas.SetLeft(tile, axisX + (tileX * tileSize));
+                    Canvas.SetTop(tile, axisY - ((tileY + 1) * tileSize));
+                    FrameCheckerboardCanvas.Children.Add(tile);
+                }
+            }
         }
 
         private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -24,9 +24,12 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Windows.ApplicationModel;
+using Windows.Graphics.Imaging;
 using Windows.Media.Core;
 using Windows.Media.Playback;
+using Windows.Storage;
 using Windows.Storage.Pickers;
+using Windows.Storage.Streams;
 using Windows.UI.Composition;
 
 namespace FramesToMMSpriteResources
@@ -233,10 +236,15 @@ namespace FramesToMMSpriteResources
         private bool _isFrameCanvasDragging;
         private float _frameCanvasZoom = 1.0f;
         private const float FrameCanvasMinZoom = 0.2f;
-        private const float FrameCanvasMaxZoom = 8.0f;
+        private const float FrameCanvasMaxZoom = 14.0f;
         private const double FrameSpriteBaseSize = 48.0;
         private WriteableBitmap? _frameCheckerBitmap;
         private byte[]? _frameCheckerPixels;
+        private byte[]? _frameSpriteSourcePixels;
+        private int _frameSpriteSourceWidth;
+        private int _frameSpriteSourceHeight;
+        private int _frameSpriteRenderedSize = -1;
+        private WriteableBitmap? _frameSpriteBitmap;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -271,6 +279,7 @@ namespace FramesToMMSpriteResources
 
             ProgramNameTextBlock.Text += GetCurrentVersion();
             InitializeFrameCoordinatePlane();
+            InitializeFrameSpriteSourceAsync();
 
         
             CheckForUpdateIfNeeded();
@@ -1474,6 +1483,76 @@ namespace FramesToMMSpriteResources
             UpdateFrameCoordinateVisuals();
         }
 
+        private async void InitializeFrameSpriteSourceAsync()
+        {
+            try
+            {
+                StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/icon.png"));
+                using IRandomAccessStream stream = await file.OpenReadAsync();
+                BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
+                PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
+                    BitmapPixelFormat.Bgra8,
+                    BitmapAlphaMode.Premultiplied,
+                    new BitmapTransform(),
+                    ExifOrientationMode.IgnoreExifOrientation,
+                    ColorManagementMode.DoNotColorManage);
+
+                _frameSpriteSourcePixels = pixelData.DetachPixelData();
+                _frameSpriteSourceWidth = (int)decoder.PixelWidth;
+                _frameSpriteSourceHeight = (int)decoder.PixelHeight;
+                _frameSpriteRenderedSize = -1;
+
+                UpdateFrameCoordinateVisuals();
+            }
+            catch
+            {
+                // Keep default image source if loading/scaling pipeline is unavailable.
+            }
+        }
+
+        private void UpdateFrameSpriteBitmap(int targetSize)
+        {
+            if (_frameSpriteSourcePixels == null || _frameSpriteSourceWidth <= 0 || _frameSpriteSourceHeight <= 0 || targetSize <= 0)
+            {
+                return;
+            }
+
+            if (_frameSpriteBitmap != null && _frameSpriteRenderedSize == targetSize)
+            {
+                return;
+            }
+
+            _frameSpriteBitmap = new WriteableBitmap(targetSize, targetSize);
+            byte[] scaledPixels = new byte[targetSize * targetSize * 4];
+
+            for (int y = 0; y < targetSize; y++)
+            {
+                int sourceY = Math.Min(_frameSpriteSourceHeight - 1, (int)((y / (double)targetSize) * _frameSpriteSourceHeight));
+                for (int x = 0; x < targetSize; x++)
+                {
+                    int sourceX = Math.Min(_frameSpriteSourceWidth - 1, (int)((x / (double)targetSize) * _frameSpriteSourceWidth));
+
+                    int src = ((sourceY * _frameSpriteSourceWidth) + sourceX) * 4;
+                    int dst = ((y * targetSize) + x) * 4;
+
+                    scaledPixels[dst] = _frameSpriteSourcePixels[src];
+                    scaledPixels[dst + 1] = _frameSpriteSourcePixels[src + 1];
+                    scaledPixels[dst + 2] = _frameSpriteSourcePixels[src + 2];
+                    scaledPixels[dst + 3] = _frameSpriteSourcePixels[src + 3];
+                }
+            }
+
+            using (Stream stream = _frameSpriteBitmap.PixelBuffer.AsStream())
+            {
+                stream.Position = 0;
+                stream.Write(scaledPixels, 0, scaledPixels.Length);
+            }
+
+            _frameSpriteBitmap.Invalidate();
+            FrameCoordinateSpriteImage.Source = _frameSpriteBitmap;
+            _frameSpriteRenderedSize = targetSize;
+        }
+
         private void UpdateFrameCoordinateVisuals()
         {
             if (FrameCoordinateCanvas == null)
@@ -1509,6 +1588,7 @@ namespace FramesToMMSpriteResources
             double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
 
             double spriteSize = FrameSpriteBaseSize * _frameCanvasZoom;
+            UpdateFrameSpriteBitmap(Math.Max(1, (int)Math.Round(spriteSize)));
             FrameCoordinateSpriteImage.Width = spriteSize;
             FrameCoordinateSpriteImage.Height = spriteSize;
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -224,6 +224,15 @@ namespace FramesToMMSpriteResources
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
 
+        private Vector2 _frameCanvasPan = Vector2.Zero;
+        private Vector2 _frameSpritePosition = Vector2.Zero;
+        private Vector2 _frameDragStartPointer;
+        private Vector2 _frameDragStartPan;
+        private bool _isFrameCanvasDragging;
+        private float _frameCanvasZoom = 1.0f;
+        private const float FrameCanvasMinZoom = 0.2f;
+        private const float FrameCanvasMaxZoom = 8.0f;
+
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
         {
@@ -256,6 +265,7 @@ namespace FramesToMMSpriteResources
             HeaderBreadcrumbBar.ItemClicked += BreadcrumbBar_ItemClicked;
 
             ProgramNameTextBlock.Text += GetCurrentVersion();
+            InitializeFrameCoordinatePlane();
 
         
             CheckForUpdateIfNeeded();
@@ -1445,6 +1455,143 @@ namespace FramesToMMSpriteResources
 
 
 
+        }
+
+        private void InitializeFrameCoordinatePlane()
+        {
+            _frameCanvasPan = Vector2.Zero;
+            _frameSpritePosition = Vector2.Zero;
+            _isFrameCanvasDragging = false;
+            _frameCanvasZoom = 1.0f;
+            FrameVectorXTextBox.Value = 0;
+            FrameVectorYTextBox.Value = 0;
+
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void UpdateFrameCoordinateVisuals()
+        {
+            if (FrameCoordinateCanvas == null)
+            {
+                return;
+            }
+
+            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
+            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
+
+            if (canvasWidth <= 0 || canvasHeight <= 0)
+            {
+                return;
+            }
+
+            double centerX = canvasWidth / 2.0;
+            double centerY = canvasHeight / 2.0;
+
+            double axisX = centerX + _frameCanvasPan.X;
+            double axisY = centerY + _frameCanvasPan.Y;
+
+            FrameXAxis.Width = canvasWidth;
+            Canvas.SetLeft(FrameXAxis, 0);
+            Canvas.SetTop(FrameXAxis, axisY - (FrameXAxis.Height / 2.0));
+
+            FrameYAxis.Height = canvasHeight;
+            Canvas.SetLeft(FrameYAxis, axisX - (FrameYAxis.Width / 2.0));
+            Canvas.SetTop(FrameYAxis, 0);
+
+            double spriteCanvasX = axisX + (_frameSpritePosition.X * _frameCanvasZoom);
+            double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
+
+            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (FrameCoordinateSpriteImage.Width / 2.0));
+            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (FrameCoordinateSpriteImage.Height / 2.0));
+
+            FrameZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_frameCanvasZoom * 100)}%";
+        }
+
+        private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameCoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+            _frameDragStartPan = _frameCanvasPan;
+            _isFrameCanvasDragging = true;
+
+            FrameCoordinateCanvas.CapturePointer(e.Pointer);
+        }
+
+        private void FrameCoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
+
+            if (_isFrameCanvasDragging)
+            {
+                _frameCanvasPan = _frameDragStartPan + (currentPosition - _frameDragStartPointer);
+                UpdateFrameCoordinateVisuals();
+            }
+        }
+
+        private void FrameCoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            _isFrameCanvasDragging = false;
+            FrameCoordinateCanvas.ReleasePointerCapture(e.Pointer);
+        }
+
+        private void FrameCoordinateCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
+            int wheelDelta = point.Properties.MouseWheelDelta;
+            if (wheelDelta == 0)
+            {
+                return;
+            }
+
+            float oldZoom = _frameCanvasZoom;
+            float zoomMultiplier = wheelDelta > 0 ? 1.1f : 0.9f;
+            float newZoom = Math.Clamp(oldZoom * zoomMultiplier, FrameCanvasMinZoom, FrameCanvasMaxZoom);
+            if (Math.Abs(newZoom - oldZoom) < 0.0001f)
+            {
+                return;
+            }
+
+            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
+            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
+            double centerX = canvasWidth / 2.0;
+            double centerY = canvasHeight / 2.0;
+
+            double oldAxisX = centerX + _frameCanvasPan.X;
+            double oldAxisY = centerY + _frameCanvasPan.Y;
+
+            double worldXUnderPointer = (point.Position.X - oldAxisX) / oldZoom;
+            double worldYUnderPointer = (oldAxisY - point.Position.Y) / oldZoom;
+
+            _frameCanvasZoom = newZoom;
+
+            double newAxisX = point.Position.X - (worldXUnderPointer * newZoom);
+            double newAxisY = point.Position.Y + (worldYUnderPointer * newZoom);
+
+            _frameCanvasPan = new Vector2(
+                (float)(newAxisX - centerX),
+                (float)(newAxisY - centerY)
+            );
+
+            UpdateFrameCoordinateVisuals();
+            e.Handled = true;
+        }
+
+        private void FrameVectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            _frameSpritePosition = new Vector2(double.IsNaN(sender.Value) ? 0 : (float)sender.Value, _frameSpritePosition.Y);
+            UpdateFrameCoordinateVisuals();
+        }
+
+        private void FrameVectorYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            _frameSpritePosition = new Vector2(_frameSpritePosition.X, double.IsNaN(sender.Value) ? 0 : (float)sender.Value);
+            UpdateFrameCoordinateVisuals();
         }
 
         private void DetachAllPanelEvents()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -8,7 +8,6 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
-using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -18,18 +17,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Windows.ApplicationModel;
-using Windows.Graphics.Imaging;
 using Windows.Media.Core;
 using Windows.Media.Playback;
-using Windows.Storage;
 using Windows.Storage.Pickers;
-using Windows.Storage.Streams;
 using Windows.UI.Composition;
 
 namespace FramesToMMSpriteResources
@@ -229,22 +224,6 @@ namespace FramesToMMSpriteResources
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
 
-        private Vector2 _frameCanvasPan = Vector2.Zero;
-        private Vector2 _frameSpritePosition = Vector2.Zero;
-        private Vector2 _frameDragStartPointer;
-        private Vector2 _frameDragStartPan;
-        private bool _isFrameCanvasDragging;
-        private float _frameCanvasZoom = 1.0f;
-        private const float FrameCanvasMinZoom = 0.2f;
-        private const float FrameCanvasMaxZoom = 14.0f;
-        private const double FrameSpriteBaseSize = 48.0;
-        private WriteableBitmap? _frameCheckerBitmap;
-        private byte[]? _frameCheckerPixels;
-        private byte[]? _frameSpriteSourcePixels;
-        private int _frameSpriteSourceWidth;
-        private int _frameSpriteSourceHeight;
-        private int _frameSpriteRenderedSize = -1;
-        private WriteableBitmap? _frameSpriteBitmap;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -278,8 +257,7 @@ namespace FramesToMMSpriteResources
             HeaderBreadcrumbBar.ItemClicked += BreadcrumbBar_ItemClicked;
 
             ProgramNameTextBlock.Text += GetCurrentVersion();
-            InitializeFrameCoordinatePlane();
-            InitializeFrameSpriteSourceAsync();
+            _ = FrameCoordinateEditorControl.SetSpriteImageUriAsync("ms-appx:///Assets/icon.png");
 
         
             CheckForUpdateIfNeeded();
@@ -1457,7 +1435,7 @@ namespace FramesToMMSpriteResources
                         currentConfigs.Add(programConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs[int.Parse(selectedNodeName)]);
                     }
 
-                   
+                    FrameCoordinateEditorControl.SpritePosition = Vector2.Zero;
 
 
 
@@ -1469,277 +1447,6 @@ namespace FramesToMMSpriteResources
 
 
 
-        }
-
-        private void InitializeFrameCoordinatePlane()
-        {
-            _frameCanvasPan = Vector2.Zero;
-            _frameSpritePosition = Vector2.Zero;
-            _isFrameCanvasDragging = false;
-            _frameCanvasZoom = 1.0f;
-            FrameVectorXTextBox.Value = 0;
-            FrameVectorYTextBox.Value = 0;
-
-            UpdateFrameCoordinateVisuals();
-        }
-
-        private async void InitializeFrameSpriteSourceAsync()
-        {
-            try
-            {
-                StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/icon.png"));
-                using IRandomAccessStream stream = await file.OpenReadAsync();
-                BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
-                PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
-                    BitmapPixelFormat.Bgra8,
-                    BitmapAlphaMode.Premultiplied,
-                    new BitmapTransform(),
-                    ExifOrientationMode.IgnoreExifOrientation,
-                    ColorManagementMode.DoNotColorManage);
-
-                _frameSpriteSourcePixels = pixelData.DetachPixelData();
-                _frameSpriteSourceWidth = (int)decoder.PixelWidth;
-                _frameSpriteSourceHeight = (int)decoder.PixelHeight;
-                _frameSpriteRenderedSize = -1;
-
-                UpdateFrameCoordinateVisuals();
-            }
-            catch
-            {
-                // Keep default image source if loading/scaling pipeline is unavailable.
-            }
-        }
-
-        private void UpdateFrameSpriteBitmap(int targetSize)
-        {
-            if (_frameSpriteSourcePixels == null || _frameSpriteSourceWidth <= 0 || _frameSpriteSourceHeight <= 0 || targetSize <= 0)
-            {
-                return;
-            }
-
-            if (_frameSpriteBitmap != null && _frameSpriteRenderedSize == targetSize)
-            {
-                return;
-            }
-
-            _frameSpriteBitmap = new WriteableBitmap(targetSize, targetSize);
-            byte[] scaledPixels = new byte[targetSize * targetSize * 4];
-
-            for (int y = 0; y < targetSize; y++)
-            {
-                int sourceY = Math.Min(_frameSpriteSourceHeight - 1, (int)((y / (double)targetSize) * _frameSpriteSourceHeight));
-                for (int x = 0; x < targetSize; x++)
-                {
-                    int sourceX = Math.Min(_frameSpriteSourceWidth - 1, (int)((x / (double)targetSize) * _frameSpriteSourceWidth));
-
-                    int src = ((sourceY * _frameSpriteSourceWidth) + sourceX) * 4;
-                    int dst = ((y * targetSize) + x) * 4;
-
-                    scaledPixels[dst] = _frameSpriteSourcePixels[src];
-                    scaledPixels[dst + 1] = _frameSpriteSourcePixels[src + 1];
-                    scaledPixels[dst + 2] = _frameSpriteSourcePixels[src + 2];
-                    scaledPixels[dst + 3] = _frameSpriteSourcePixels[src + 3];
-                }
-            }
-
-            using (Stream stream = _frameSpriteBitmap.PixelBuffer.AsStream())
-            {
-                stream.Position = 0;
-                stream.Write(scaledPixels, 0, scaledPixels.Length);
-            }
-
-            _frameSpriteBitmap.Invalidate();
-            FrameCoordinateSpriteImage.Source = _frameSpriteBitmap;
-            _frameSpriteRenderedSize = targetSize;
-        }
-
-        private void UpdateFrameCoordinateVisuals()
-        {
-            if (FrameCoordinateCanvas == null)
-            {
-                return;
-            }
-
-            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
-            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
-
-            if (canvasWidth <= 0 || canvasHeight <= 0)
-            {
-                return;
-            }
-
-            double centerX = canvasWidth / 2.0;
-            double centerY = canvasHeight / 2.0;
-
-            double axisX = centerX + _frameCanvasPan.X;
-            double axisY = centerY + _frameCanvasPan.Y;
-
-            UpdateFrameCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
-
-            FrameXAxis.Width = canvasWidth;
-            Canvas.SetLeft(FrameXAxis, 0);
-            Canvas.SetTop(FrameXAxis, axisY - (FrameXAxis.Height / 2.0));
-
-            FrameYAxis.Height = canvasHeight;
-            Canvas.SetLeft(FrameYAxis, axisX - (FrameYAxis.Width / 2.0));
-            Canvas.SetTop(FrameYAxis, 0);
-
-            double spriteCanvasX = axisX + (_frameSpritePosition.X * _frameCanvasZoom);
-            double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
-
-            double spriteSize = FrameSpriteBaseSize * _frameCanvasZoom;
-            UpdateFrameSpriteBitmap(Math.Max(1, (int)Math.Round(spriteSize)));
-            FrameCoordinateSpriteImage.Width = spriteSize;
-            FrameCoordinateSpriteImage.Height = spriteSize;
-
-            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (spriteSize / 2.0));
-            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (spriteSize / 2.0));
-
-            FrameZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_frameCanvasZoom * 100)}%";
-        }
-
-        private void UpdateFrameCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
-        {
-            int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
-            int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
-            int pixelCount = pixelWidth * pixelHeight;
-            int byteCount = pixelCount * 4;
-
-            if (_frameCheckerBitmap == null || _frameCheckerBitmap.PixelWidth != pixelWidth || _frameCheckerBitmap.PixelHeight != pixelHeight)
-            {
-                _frameCheckerBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
-                _frameCheckerPixels = new byte[byteCount];
-                FrameCheckerboardImage.Source = _frameCheckerBitmap;
-            }
-            else if (_frameCheckerPixels == null || _frameCheckerPixels.Length != byteCount)
-            {
-                _frameCheckerPixels = new byte[byteCount];
-            }
-
-            double tileSize = 4.0 * _frameCanvasZoom;
-            if (tileSize <= 0.0001)
-            {
-                return;
-            }
-
-            const byte light = 238;
-            const byte dark = 206;
-            int idx = 0;
-
-            for (int y = 0; y < pixelHeight; y++)
-            {
-                int tileY = (int)Math.Floor((axisY - y) / tileSize);
-                for (int x = 0; x < pixelWidth; x++)
-                {
-                    int tileX = (int)Math.Floor((x - axisX) / tileSize);
-                    byte color = ((tileX + tileY) & 1) == 0 ? light : dark;
-
-                    _frameCheckerPixels![idx++] = color;
-                    _frameCheckerPixels[idx++] = color;
-                    _frameCheckerPixels[idx++] = color;
-                    _frameCheckerPixels[idx++] = 255;
-                }
-            }
-
-            using (Stream stream = _frameCheckerBitmap!.PixelBuffer.AsStream())
-            {
-                stream.Position = 0;
-                stream.Write(_frameCheckerPixels!, 0, _frameCheckerPixels!.Length);
-            }
-            _frameCheckerBitmap.Invalidate();
-        }
-
-        private void FrameCoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            UpdateFrameCoordinateVisuals();
-        }
-
-        private void FrameCoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
-        {
-            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
-            _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
-            _frameDragStartPan = _frameCanvasPan;
-            _isFrameCanvasDragging = true;
-
-            FrameCoordinateCanvas.CapturePointer(e.Pointer);
-        }
-
-        private void FrameCoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
-        {
-            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
-            var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
-
-            if (_isFrameCanvasDragging)
-            {
-                _frameCanvasPan = _frameDragStartPan + (currentPosition - _frameDragStartPointer);
-                UpdateFrameCoordinateVisuals();
-            }
-        }
-
-        private void FrameCoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
-        {
-            _isFrameCanvasDragging = false;
-            FrameCoordinateCanvas.ReleasePointerCapture(e.Pointer);
-        }
-
-        private void FrameCoordinateCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
-        {
-            var point = e.GetCurrentPoint(FrameCoordinateCanvas);
-            int wheelDelta = point.Properties.MouseWheelDelta;
-            if (wheelDelta == 0)
-            {
-                return;
-            }
-
-            float oldZoom = _frameCanvasZoom;
-            float zoomMultiplier = wheelDelta > 0 ? 1.1f : 0.9f;
-            float newZoom = Math.Clamp(oldZoom * zoomMultiplier, FrameCanvasMinZoom, FrameCanvasMaxZoom);
-            if (Math.Abs(newZoom - oldZoom) < 0.0001f)
-            {
-                return;
-            }
-
-            double canvasWidth = FrameCoordinateCanvas.ActualWidth;
-            double canvasHeight = FrameCoordinateCanvas.ActualHeight;
-            double centerX = canvasWidth / 2.0;
-            double centerY = canvasHeight / 2.0;
-
-            double oldAxisX = centerX + _frameCanvasPan.X;
-            double oldAxisY = centerY + _frameCanvasPan.Y;
-
-            double worldXUnderPointer = (point.Position.X - oldAxisX) / oldZoom;
-            double worldYUnderPointer = (oldAxisY - point.Position.Y) / oldZoom;
-
-            _frameCanvasZoom = newZoom;
-
-            double newAxisX = point.Position.X - (worldXUnderPointer * newZoom);
-            double newAxisY = point.Position.Y + (worldYUnderPointer * newZoom);
-
-            _frameCanvasPan = new Vector2(
-                (float)(newAxisX - centerX),
-                (float)(newAxisY - centerY)
-            );
-
-            UpdateFrameCoordinateVisuals();
-            e.Handled = true;
-        }
-
-        private void CenterFrameOriginButton_Click(object sender, RoutedEventArgs e)
-        {
-            _frameCanvasPan = Vector2.Zero;
-            UpdateFrameCoordinateVisuals();
-        }
-
-        private void FrameVectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
-        {
-            _frameSpritePosition = new Vector2(double.IsNaN(sender.Value) ? 0 : (float)sender.Value, _frameSpritePosition.Y);
-            UpdateFrameCoordinateVisuals();
-        }
-
-        private void FrameVectorYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
-        {
-            _frameSpritePosition = new Vector2(_frameSpritePosition.X, double.IsNaN(sender.Value) ? 0 : (float)sender.Value);
-            UpdateFrameCoordinateVisuals();
         }
 
         private void DetachAllPanelEvents()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -232,6 +232,9 @@ namespace FramesToMMSpriteResources
         private float _frameCanvasZoom = 1.0f;
         private const float FrameCanvasMinZoom = 0.2f;
         private const float FrameCanvasMaxZoom = 8.0f;
+        private const double FrameSpriteBaseSize = 48.0;
+        private const double FrameSpriteMinSize = 14.0;
+        private const double FrameSpriteMaxSize = 256.0;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -1501,8 +1504,12 @@ namespace FramesToMMSpriteResources
             double spriteCanvasX = axisX + (_frameSpritePosition.X * _frameCanvasZoom);
             double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
 
-            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (FrameCoordinateSpriteImage.Width / 2.0));
-            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (FrameCoordinateSpriteImage.Height / 2.0));
+            double spriteSize = Math.Clamp(FrameSpriteBaseSize * _frameCanvasZoom, FrameSpriteMinSize, FrameSpriteMaxSize);
+            FrameCoordinateSpriteImage.Width = spriteSize;
+            FrameCoordinateSpriteImage.Height = spriteSize;
+
+            Canvas.SetLeft(FrameCoordinateSpriteImage, spriteCanvasX - (spriteSize / 2.0));
+            Canvas.SetTop(FrameCoordinateSpriteImage, spriteCanvasY - (spriteSize / 2.0));
 
             FrameZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_frameCanvasZoom * 100)}%";
         }

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -234,7 +234,6 @@ namespace FramesToMMSpriteResources
         private const float FrameCanvasMaxZoom = 8.0f;
         private const double FrameSpriteBaseSize = 48.0;
         private const double FrameSpriteMinSize = 14.0;
-        private const double FrameSpriteMaxSize = 256.0;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TreeItem))]
         public MainWindow()
@@ -1504,7 +1503,7 @@ namespace FramesToMMSpriteResources
             double spriteCanvasX = axisX + (_frameSpritePosition.X * _frameCanvasZoom);
             double spriteCanvasY = axisY - (_frameSpritePosition.Y * _frameCanvasZoom);
 
-            double spriteSize = Math.Clamp(FrameSpriteBaseSize * _frameCanvasZoom, FrameSpriteMinSize, FrameSpriteMaxSize);
+            double spriteSize = Math.Max(FrameSpriteBaseSize * _frameCanvasZoom, FrameSpriteMinSize);
             FrameCoordinateSpriteImage.Width = spriteSize;
             FrameCoordinateSpriteImage.Height = spriteSize;
 
@@ -1587,6 +1586,12 @@ namespace FramesToMMSpriteResources
 
             UpdateFrameCoordinateVisuals();
             e.Handled = true;
+        }
+
+        private void CenterFrameOriginButton_Click(object sender, RoutedEventArgs e)
+        {
+            _frameCanvasPan = Vector2.Zero;
+            UpdateFrameCoordinateVisuals();
         }
 
         private void FrameVectorXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1467,7 +1467,6 @@ namespace FramesToMMSpriteResources
             _frameSpritePosition = Vector2.Zero;
             _isFrameCanvasDragging = false;
             _frameCanvasZoom = 1.0f;
-            RenderOptions.SetBitmapInterpolationMode(FrameCoordinateSpriteImage, BitmapInterpolationMode.NearestNeighbor);
             FrameVectorXTextBox.Value = 0;
             FrameVectorYTextBox.Value = 0;
 
@@ -1524,30 +1523,43 @@ namespace FramesToMMSpriteResources
             FrameCheckerboardCanvas.Height = canvasHeight;
             FrameCheckerboardCanvas.Children.Clear();
 
-            double tileSize = 4.0 * _frameCanvasZoom;
-            if (tileSize <= 0)
+            double baseTileSize = 4.0 * _frameCanvasZoom;
+            if (baseTileSize <= 0)
             {
                 return;
             }
 
-            int minTileX = (int)Math.Floor((-axisX) / tileSize) - 1;
-            int maxTileX = (int)Math.Ceiling((canvasWidth - axisX) / tileSize) + 1;
-            int minTileY = (int)Math.Floor((axisY - canvasHeight) / tileSize) - 1;
-            int maxTileY = (int)Math.Ceiling(axisY / tileSize) + 1;
+            int stride = 1;
+            double tileSize = baseTileSize;
 
-            for (int tileY = minTileY; tileY <= maxTileY; tileY++)
+            int estimatedColumns = (int)Math.Ceiling(canvasWidth / tileSize) + 2;
+            int estimatedRows = (int)Math.Ceiling(canvasHeight / tileSize) + 2;
+            while ((estimatedColumns * estimatedRows) > 6000)
             {
-                for (int tileX = minTileX; tileX <= maxTileX; tileX++)
+                stride *= 2;
+                tileSize = baseTileSize * stride;
+                estimatedColumns = (int)Math.Ceiling(canvasWidth / tileSize) + 2;
+                estimatedRows = (int)Math.Ceiling(canvasHeight / tileSize) + 2;
+            }
+
+            int minTileX = (int)Math.Floor((-axisX) / baseTileSize) - stride;
+            int maxTileX = (int)Math.Ceiling((canvasWidth - axisX) / baseTileSize) + stride;
+            int minTileY = (int)Math.Floor((axisY - canvasHeight) / baseTileSize) - stride;
+            int maxTileY = (int)Math.Ceiling(axisY / baseTileSize) + stride;
+
+            for (int tileY = minTileY; tileY <= maxTileY; tileY += stride)
+            {
+                for (int tileX = minTileX; tileX <= maxTileX; tileX += stride)
                 {
                     var tile = new Microsoft.UI.Xaml.Shapes.Rectangle
                     {
                         Width = tileSize,
                         Height = tileSize,
-                        Fill = ((tileX + tileY) & 1) == 0 ? _frameCheckerLightBrush : _frameCheckerDarkBrush
+                        Fill = (((tileX / stride) + (tileY / stride)) & 1) == 0 ? _frameCheckerLightBrush : _frameCheckerDarkBrush
                     };
 
-                    Canvas.SetLeft(tile, axisX + (tileX * tileSize));
-                    Canvas.SetTop(tile, axisY - ((tileY + 1) * tileSize));
+                    Canvas.SetLeft(tile, axisX + (tileX * baseTileSize));
+                    Canvas.SetTop(tile, axisY - ((tileY + stride) * baseTileSize));
                     FrameCheckerboardCanvas.Children.Add(tile);
                 }
             }


### PR DESCRIPTION
### Motivation
- Provide a visual coordinate plane in the Frame panel so users can pan/zoom and set sprite offsets interactively.
- Surface numeric X/Y controls and a zoom indicator so frame coordinates can be edited precisely.

### Description
- Added XAML UI for the frame coordinate area including `FrameCoordinateCanvas`, `FrameVectorXTextBox`, `FrameVectorYTextBox`, axis visuals and a sprite preview image, plus helper text and zoom label.
- Introduced state fields (`_frameCanvasPan`, `_frameSpritePosition`, `_frameDragStartPointer`, `_frameDragStartPan`, `_isFrameCanvasDragging`, `_frameCanvasZoom`) and constants for zoom limits (`FrameCanvasMinZoom`, `FrameCanvasMaxZoom`).
- Implemented `InitializeFrameCoordinatePlane`, `UpdateFrameCoordinateVisuals`, and event handlers `FrameCoordinateCanvas_SizeChanged`, `FrameCoordinateCanvas_PointerPressed`, `FrameCoordinateCanvas_PointerMoved`, `FrameCoordinateCanvas_PointerReleased`, `FrameCoordinateCanvas_PointerWheelChanged`, `FrameVectorXTextBox_ValueChanged`, and `FrameVectorYTextBox_ValueChanged` to support pan/zoom, pointer capture, zoom centering under pointer, and numeric updates.
- Wired initialization by calling `InitializeFrameCoordinatePlane()` from the constructor and updated visuals to reflect pan/zoom/position changes.

### Testing
- Built the solution with `dotnet build` and the build succeeded.
- Ran `dotnet test` against the repository test suite and any existing tests completed without failures (no new automated tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7c93451c8327b685b9c7f74633c1)