### PR TITLE
Fix sprite pixel-based sizing in frame coordinate editor

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -2,40 +2,17 @@
     x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch">
-        <StackPanel Spacing="12">
-            <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
-            <Rectangle Style="{StaticResource GroupDividerStyle}"/>
-            <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
-                       Style="{StaticResource HelperTextStyle}"/>
-            <Grid ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock x:Name="ZoomTextBlock" Grid.Column="0" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}" VerticalAlignment="Center"/>
-                <Button Grid.Column="1" Click="CenterOriginButton_Click">
-                    <StackPanel Orientation="Horizontal" Spacing="6">
-                        <FontIcon Glyph="&#xE777;" FontSize="12"/>
-                        <TextBlock Text="Center origin"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
+    <Border Style="{StaticResource CardBorderStyle}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+        <Grid ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="280"/>
+            </Grid.ColumnDefinitions>
 
-            <Grid ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <NumberBox x:Name="VectorXTextBox" Grid.Column="0" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="VectorXTextBox_ValueChanged"/>
-                <NumberBox x:Name="VectorYTextBox" Grid.Column="1" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="VectorYTextBox_ValueChanged"/>
-            </Grid>
-
-            <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
+            <Border Grid.Column="0" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
                 <Canvas x:Name="CoordinateCanvas"
-                        Height="320"
                         HorizontalAlignment="Stretch"
-                        VerticalAlignment="Top"
+                        VerticalAlignment="Stretch"
                         Background="Transparent"
                         SizeChanged="CoordinateCanvas_SizeChanged"
                         PointerPressed="CoordinateCanvas_PointerPressed"
@@ -47,9 +24,23 @@
                     <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False"/>
                     <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                     <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                    
                 </Canvas>
             </Border>
-        </StackPanel>
+
+            <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
+                <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
+                           Style="{StaticResource HelperTextStyle}" TextWrapping="Wrap"/>
+                <TextBlock x:Name="ZoomTextBlock" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}"/>
+                <Button Click="CenterOriginButton_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon Glyph="&#xE777;" FontSize="12"/>
+                        <TextBlock Text="Center origin"/>
+                    </StackPanel>
+                </Button>
+                <NumberBox x:Name="VectorXTextBox" Header="Vector2 X" Minimum="-999999" Maximum="999999" ValueChanged="VectorXTextBox_ValueChanged"/>
+                <NumberBox x:Name="VectorYTextBox" Header="Vector2 Y" Minimum="-999999" Maximum="999999" ValueChanged="VectorYTextBox_ValueChanged"/>
+            </StackPanel>
+        </Grid>
     </Border>
 </UserControl>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -20,7 +20,7 @@
                         PointerReleased="CoordinateCanvas_PointerReleased"
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
                         PointerExited="CoordinateCanvas_PointerReleased">
-                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="Fill"/>
+                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
                     <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False"/>
                     <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                     <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
@@ -31,7 +31,26 @@
                 <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
                 <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
                            Style="{StaticResource HelperTextStyle}" TextWrapping="Wrap"/>
-                <TextBlock x:Name="ZoomTextBlock" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}"/>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="90"/>
+                    </Grid.ColumnDefinitions>
+                    <Slider x:Name="ZoomSlider"
+                            Grid.Column="0"
+                            Header="Zoom"
+                            Minimum="30"
+                            Maximum="1800"
+                            StepFrequency="1"
+                            ValueChanged="ZoomSlider_ValueChanged"/>
+                    <NumberBox x:Name="ZoomNumberBox"
+                               Grid.Column="1"
+                               Header="%"
+                               Minimum="30"
+                               Maximum="1800"
+                               SpinButtonPlacementMode="Compact"
+                               ValueChanged="ZoomNumberBox_ValueChanged"/>
+                </Grid>
                 <Button Click="CenterOriginButton_Click">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE777;" FontSize="12"/>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -20,7 +20,7 @@
                         PointerReleased="CoordinateCanvas_PointerReleased"
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
                         PointerExited="CoordinateCanvas_PointerReleased">
-                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
+                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="Fill"/>
                     <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False"/>
                     <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                     <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
@@ -31,26 +31,7 @@
                 <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
                 <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
                            Style="{StaticResource HelperTextStyle}" TextWrapping="Wrap"/>
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="90"/>
-                    </Grid.ColumnDefinitions>
-                    <Slider x:Name="ZoomSlider"
-                            Grid.Column="0"
-                            Header="Zoom"
-                            Minimum="30"
-                            Maximum="1800"
-                            StepFrequency="1"
-                            ValueChanged="ZoomSlider_ValueChanged"/>
-                    <NumberBox x:Name="ZoomNumberBox"
-                               Grid.Column="1"
-                               Header="%"
-                               Minimum="30"
-                               Maximum="1800"
-                               SpinButtonPlacementMode="Compact"
-                               ValueChanged="ZoomNumberBox_ValueChanged"/>
-                </Grid>
+                <TextBlock x:Name="ZoomTextBlock" Text="Zoom: 100%" Style="{StaticResource HelperTextStyle}"/>
                 <Button Click="CenterOriginButton_Click">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE777;" FontSize="12"/>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -6,7 +6,7 @@
         <Grid ColumnSpacing="12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="280"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <Border Grid.Column="0" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
@@ -27,7 +27,7 @@
                 </Canvas>
             </Border>
 
-            <StackPanel Grid.Column="1" Spacing="8">
+            <StackPanel Grid.Column="1" Spacing="8" MinWidth="180">
                 <TextBlock Text="Frame coordinates" Style="{StaticResource SectionHeaderStyle}"/>
                 <TextBlock Text="Drag to pan, mouse wheel to zoom, or edit Vector2 directly."
                            Style="{StaticResource HelperTextStyle}" TextWrapping="Wrap"/>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Dispatching;
 using System;
 using System.IO;
 using System.Numerics;
@@ -34,12 +35,24 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _spriteRenderedHeight = -1;
     private WriteableBitmap? _spriteBitmap;
     private CancellationTokenSource? _spriteRenderCts;
+    private readonly DispatcherQueueTimer _spriteRenderTimer;
+    private int _pendingSpriteWidth;
+    private int _pendingSpriteHeight;
+    private const int CheckerRenderScale = 2;
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
+        _spriteRenderTimer = DispatcherQueue.CreateTimer();
+        _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(45);
+        _spriteRenderTimer.IsRepeating = false;
+        _spriteRenderTimer.Tick += (_, _) =>
+        {
+            _spriteRenderTimer.Stop();
+            StartSpriteBitmapRender(_pendingSpriteWidth, _pendingSpriteHeight);
+        };
         _ = SetSpriteImageUriAsync("ms-appx:///Assets/icon.png");
         UpdateVisuals();
     }
@@ -76,6 +89,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteRenderedWidth = -1;
         _spriteRenderedHeight = -1;
         _spriteRenderCts?.Cancel();
+        _spriteRenderTimer.Stop();
         UpdateVisuals();
     }
 
@@ -119,8 +133,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
     {
-        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
-        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
+        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth / CheckerRenderScale));
+        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight / CheckerRenderScale));
         int byteCount = pixelWidth * pixelHeight * 4;
 
         if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
@@ -138,10 +152,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-            int tileY = (int)Math.Floor((axisY - y) / tileSize);
+            double sampledCanvasY = y * CheckerRenderScale;
+            int tileY = (int)Math.Floor((axisY - sampledCanvasY) / tileSize);
             for (int x = 0; x < pixelWidth; x++)
             {
-                int tileX = (int)Math.Floor((x - axisX) / tileSize);
+                double sampledCanvasX = x * CheckerRenderScale;
+                int tileX = (int)Math.Floor((sampledCanvasX - axisX) / tileSize);
                 byte color = ((tileX + tileY) & 1) == 0 ? (byte)30 : (byte)60;
 
                 _checkerPixels![idx++] = color;
@@ -172,8 +188,21 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         _spriteRenderedWidth = targetWidth;
         _spriteRenderedHeight = targetHeight;
+        _pendingSpriteWidth = targetWidth;
+        _pendingSpriteHeight = targetHeight;
 
         _spriteRenderCts?.Cancel();
+        _spriteRenderTimer.Stop();
+        _spriteRenderTimer.Start();
+    }
+
+    private void StartSpriteBitmapRender(int targetWidth, int targetHeight)
+    {
+        if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
+        {
+            return;
+        }
+
         _spriteRenderCts = new CancellationTokenSource();
         CancellationToken token = _spriteRenderCts.Token;
         byte[] sourcePixels = _spriteSourcePixels;

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -73,7 +73,15 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public async System.Threading.Tasks.Task SetSpriteImageUriAsync(string uri)
     {
-        StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
+        StorageFile file;
+        if (Path.IsPathRooted(uri))
+        {
+            file = await StorageFile.GetFileFromPathAsync(uri);
+        }
+        else
+        {
+            file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
+        }
         using IRandomAccessStream stream = await file.OpenReadAsync();
         BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
         PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
@@ -108,6 +116,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double axisY = centerY + _pan.Y;
 
         UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
+        CheckerboardImage.Width = canvasWidth;
+        CheckerboardImage.Height = canvasHeight;
+        Canvas.SetLeft(CheckerboardImage, 0);
+        Canvas.SetTop(CheckerboardImage, 0);
 
         XAxis.Width = canvasWidth;
         Canvas.SetLeft(XAxis, 0);

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Dispatching;
@@ -40,12 +41,15 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _pendingSpriteHeight;
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
+    private bool _isUpdatingZoomControls;
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
+        ZoomSlider.Value = 100;
+        ZoomNumberBox.Value = 100;
         _spriteRenderTimer = DispatcherQueue.CreateTimer();
         _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(120);
         _spriteRenderTimer.IsRepeating = false;
@@ -117,8 +121,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double axisY = centerY + _pan.Y;
 
         UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
-        CheckerboardImage.Width = canvasWidth;
-        CheckerboardImage.Height = canvasHeight;
+        CheckerboardImage.Width = _checkerBitmap?.PixelWidth ?? canvasWidth;
+        CheckerboardImage.Height = _checkerBitmap?.PixelHeight ?? canvasHeight;
         Canvas.SetLeft(CheckerboardImage, 0);
         Canvas.SetTop(CheckerboardImage, 0);
 
@@ -141,7 +145,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteWidth / 2.0));
         Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteHeight / 2.0));
 
-        ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
+        UpdateZoomControls();
     }
 
     private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
@@ -369,6 +373,56 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _pan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
         UpdateVisuals();
         e.Handled = true;
+    }
+
+    private void UpdateZoomControls()
+    {
+        if (_isUpdatingZoomControls)
+        {
+            return;
+        }
+
+        _isUpdatingZoomControls = true;
+        double zoomPercent = Math.Round(_zoom * 100);
+        ZoomSlider.Value = zoomPercent;
+        ZoomNumberBox.Value = zoomPercent;
+        _isUpdatingZoomControls = false;
+    }
+
+    private void ZoomSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+    {
+        if (_isUpdatingZoomControls)
+        {
+            return;
+        }
+
+        float newZoom = Math.Clamp((float)e.NewValue / 100.0f, MinZoom, MaxZoom);
+        if (Math.Abs(newZoom - _zoom) < 0.0001f)
+        {
+            return;
+        }
+
+        _zoom = newZoom;
+        _lastInteractionUtc = DateTime.UtcNow;
+        UpdateVisuals();
+    }
+
+    private void ZoomNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        if (_isUpdatingZoomControls || double.IsNaN(sender.Value))
+        {
+            return;
+        }
+
+        float newZoom = Math.Clamp((float)sender.Value / 100.0f, MinZoom, MaxZoom);
+        if (Math.Abs(newZoom - _zoom) < 0.0001f)
+        {
+            return;
+        }
+
+        _zoom = newZoom;
+        _lastInteractionUtc = DateTime.UtcNow;
+        UpdateVisuals();
     }
 
     private void CenterOriginButton_Click(object sender, RoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,7 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.IO;
@@ -61,7 +60,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteSourceWidth = (int)decoder.PixelWidth;
         _spriteSourceHeight = (int)decoder.PixelHeight;
         SpriteImage.Source = new BitmapImage(new Uri(uri));
-        RenderOptions.SetBitmapInterpolationMode(SpriteImage, BitmapInterpolationMode.NearestNeighbor);
         UpdateVisuals();
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -38,8 +38,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly DispatcherQueueTimer _spriteRenderTimer;
     private int _pendingSpriteWidth;
     private int _pendingSpriteHeight;
-    private const int CheckerRenderScaleIdle = 2;
-    private const int CheckerRenderScaleInteractive = 4;
+    private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
 
     public FrameCoordinateEditor()
@@ -48,7 +47,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
         _spriteRenderTimer = DispatcherQueue.CreateTimer();
-        _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(45);
+        _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(120);
         _spriteRenderTimer.IsRepeating = false;
         _spriteRenderTimer.Tick += (_, _) =>
         {
@@ -147,10 +146,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
     {
-        bool isInteractive = _isDragging || (DateTime.UtcNow - _lastInteractionUtc).TotalMilliseconds < 180;
-        int checkerRenderScale = isInteractive ? CheckerRenderScaleInteractive : CheckerRenderScaleIdle;
-        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth / checkerRenderScale));
-        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight / checkerRenderScale));
+        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth / CheckerRenderScale));
+        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight / CheckerRenderScale));
         int byteCount = pixelWidth * pixelHeight * 4;
 
         if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
@@ -168,11 +165,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-            double sampledCanvasY = y * checkerRenderScale;
+            double sampledCanvasY = y * CheckerRenderScale;
             int tileY = (int)Math.Floor((axisY - sampledCanvasY) / tileSize);
             for (int x = 0; x < pixelWidth; x++)
             {
-                double sampledCanvasX = x * checkerRenderScale;
+                double sampledCanvasX = x * CheckerRenderScale;
                 int tileX = (int)Math.Floor((sampledCanvasX - axisX) / tileSize);
                 byte color = ((tileX + tileY) & 1) == 0 ? (byte)30 : (byte)60;
 
@@ -216,6 +213,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
         {
+            return;
+        }
+
+        if (_isDragging || (DateTime.UtcNow - _lastInteractionUtc).TotalMilliseconds < 120)
+        {
+            _spriteRenderTimer.Stop();
+            _spriteRenderTimer.Start();
             return;
         }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -22,15 +22,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private float _zoom = 1.0f;
     private const float MinZoom = 0.3f;
     private const float MaxZoom = 18.0f;
-    private const double SpriteBaseSize = 48.0;
-
     private WriteableBitmap? _checkerBitmap;
     private byte[]? _checkerPixels;
 
     private byte[]? _spriteSourcePixels;
     private int _spriteSourceWidth;
     private int _spriteSourceHeight;
-    private int _spriteRenderedSize = -1;
+    private int _spriteRenderedWidth = -1;
+    private int _spriteRenderedHeight = -1;
     private WriteableBitmap? _spriteBitmap;
 
     public FrameCoordinateEditor()
@@ -71,7 +70,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteSourcePixels = pixelData.DetachPixelData();
         _spriteSourceWidth = (int)decoder.PixelWidth;
         _spriteSourceHeight = (int)decoder.PixelHeight;
-        _spriteRenderedSize = -1;
+        _spriteRenderedWidth = -1;
+        _spriteRenderedHeight = -1;
         UpdateVisuals();
     }
 
@@ -99,15 +99,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Canvas.SetLeft(YAxis, axisX - (YAxis.Width / 2.0));
         Canvas.SetTop(YAxis, 0);
 
-        double spriteSize = SpriteBaseSize * _zoom;
-        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteSize)));
+        double spriteWidth = Math.Max(1.0, _spriteSourceWidth * _zoom);
+        double spriteHeight = Math.Max(1.0, _spriteSourceHeight * _zoom);
+        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
-        SpriteImage.Width = spriteSize;
-        SpriteImage.Height = spriteSize;
-        Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteSize / 2.0));
-        Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteSize / 2.0));
+        SpriteImage.Width = spriteWidth;
+        SpriteImage.Height = spriteHeight;
+        Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteWidth / 2.0));
+        Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteHeight / 2.0));
 
         ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
     }
@@ -152,30 +153,30 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _checkerBitmap.Invalidate();
     }
 
-    private void UpdateSpriteBitmap(int targetSize)
+    private void UpdateSpriteBitmap(int targetWidth, int targetHeight)
     {
         if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
         {
             return;
         }
 
-        if (_spriteBitmap != null && _spriteRenderedSize == targetSize)
+        if (_spriteBitmap != null && _spriteRenderedWidth == targetWidth && _spriteRenderedHeight == targetHeight)
         {
             SpriteImage.Source = _spriteBitmap;
             return;
         }
 
-        _spriteBitmap = new WriteableBitmap(targetSize, targetSize);
-        byte[] scaled = new byte[targetSize * targetSize * 4];
+        _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
+        byte[] scaled = new byte[targetWidth * targetHeight * 4];
 
-        for (int y = 0; y < targetSize; y++)
+        for (int y = 0; y < targetHeight; y++)
         {
-            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetSize) * _spriteSourceHeight));
-            for (int x = 0; x < targetSize; x++)
+            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetHeight) * _spriteSourceHeight));
+            for (int x = 0; x < targetWidth; x++)
             {
-                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetSize) * _spriteSourceWidth));
+                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetWidth) * _spriteSourceWidth));
                 int src = ((sy * _spriteSourceWidth) + sx) * 4;
-                int dst = ((y * targetSize) + x) * 4;
+                int dst = ((y * targetWidth) + x) * 4;
                 scaled[dst] = _spriteSourcePixels[src];
                 scaled[dst + 1] = _spriteSourcePixels[src + 1];
                 scaled[dst + 2] = _spriteSourcePixels[src + 2];
@@ -189,7 +190,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteBitmap.Invalidate();
 
         SpriteImage.Source = _spriteBitmap;
-        _spriteRenderedSize = targetSize;
+        _spriteRenderedWidth = targetWidth;
+        _spriteRenderedHeight = targetHeight;
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e) => UpdateVisuals();

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -38,7 +38,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly DispatcherQueueTimer _spriteRenderTimer;
     private int _pendingSpriteWidth;
     private int _pendingSpriteHeight;
-    private const int CheckerRenderScale = 2;
+    private const int CheckerRenderScaleIdle = 2;
+    private const int CheckerRenderScaleInteractive = 4;
+    private DateTime _lastInteractionUtc = DateTime.MinValue;
 
     public FrameCoordinateEditor()
     {
@@ -145,8 +147,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
     {
-        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth / CheckerRenderScale));
-        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight / CheckerRenderScale));
+        bool isInteractive = _isDragging || (DateTime.UtcNow - _lastInteractionUtc).TotalMilliseconds < 180;
+        int checkerRenderScale = isInteractive ? CheckerRenderScaleInteractive : CheckerRenderScaleIdle;
+        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth / checkerRenderScale));
+        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight / checkerRenderScale));
         int byteCount = pixelWidth * pixelHeight * 4;
 
         if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
@@ -164,11 +168,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-            double sampledCanvasY = y * CheckerRenderScale;
+            double sampledCanvasY = y * checkerRenderScale;
             int tileY = (int)Math.Floor((axisY - sampledCanvasY) / tileSize);
             for (int x = 0; x < pixelWidth; x++)
             {
-                double sampledCanvasX = x * CheckerRenderScale;
+                double sampledCanvasX = x * checkerRenderScale;
                 int tileX = (int)Math.Floor((sampledCanvasX - axisX) / tileSize);
                 byte color = ((tileX + tileY) & 1) == 0 ? (byte)30 : (byte)60;
 
@@ -303,6 +307,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _dragStartPan = _pan;
         _isDragging = true;
+        _lastInteractionUtc = DateTime.UtcNow;
         CoordinateCanvas.CapturePointer(e.Pointer);
     }
 
@@ -316,6 +321,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         var point = e.GetCurrentPoint(CoordinateCanvas);
         var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _pan = _dragStartPan + (currentPosition - _dragStartPointer);
+        _lastInteractionUtc = DateTime.UtcNow;
         UpdateVisuals();
     }
 
@@ -351,6 +357,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double worldY = (oldAxisY - point.Position.Y) / oldZoom;
 
         _zoom = newZoom;
+        _lastInteractionUtc = DateTime.UtcNow;
 
         double newAxisX = point.Position.X - (worldX * newZoom);
         double newAxisY = point.Position.Y + (worldY * newZoom);
@@ -363,6 +370,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void CenterOriginButton_Click(object sender, RoutedEventArgs e)
     {
         _pan = Vector2.Zero;
+        _lastInteractionUtc = DateTime.UtcNow;
         UpdateVisuals();
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -6,6 +6,8 @@ using System;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
+using System.Threading.Tasks;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Streams;
@@ -31,6 +33,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _spriteRenderedWidth = -1;
     private int _spriteRenderedHeight = -1;
     private WriteableBitmap? _spriteBitmap;
+    private CancellationTokenSource? _spriteRenderCts;
 
     public FrameCoordinateEditor()
     {
@@ -72,6 +75,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteSourceHeight = (int)decoder.PixelHeight;
         _spriteRenderedWidth = -1;
         _spriteRenderedHeight = -1;
+        _spriteRenderCts?.Cancel();
         UpdateVisuals();
     }
 
@@ -101,7 +105,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         double spriteWidth = Math.Max(1.0, _spriteSourceWidth * _zoom);
         double spriteHeight = Math.Max(1.0, _spriteSourceHeight * _zoom);
-        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
+        RequestSpriteBitmapUpdate(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
@@ -153,7 +157,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _checkerBitmap.Invalidate();
     }
 
-    private void UpdateSpriteBitmap(int targetWidth, int targetHeight)
+    private void RequestSpriteBitmapUpdate(int targetWidth, int targetHeight)
     {
         if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
         {
@@ -166,32 +170,85 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return;
         }
 
-        _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
-        byte[] scaled = new byte[targetWidth * targetHeight * 4];
-
-        for (int y = 0; y < targetHeight; y++)
-        {
-            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetHeight) * _spriteSourceHeight));
-            for (int x = 0; x < targetWidth; x++)
-            {
-                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetWidth) * _spriteSourceWidth));
-                int src = ((sy * _spriteSourceWidth) + sx) * 4;
-                int dst = ((y * targetWidth) + x) * 4;
-                scaled[dst] = _spriteSourcePixels[src];
-                scaled[dst + 1] = _spriteSourcePixels[src + 1];
-                scaled[dst + 2] = _spriteSourcePixels[src + 2];
-                scaled[dst + 3] = _spriteSourcePixels[src + 3];
-            }
-        }
-
-        using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
-        stream.Position = 0;
-        stream.Write(scaled, 0, scaled.Length);
-        _spriteBitmap.Invalidate();
-
-        SpriteImage.Source = _spriteBitmap;
         _spriteRenderedWidth = targetWidth;
         _spriteRenderedHeight = targetHeight;
+
+        _spriteRenderCts?.Cancel();
+        _spriteRenderCts = new CancellationTokenSource();
+        CancellationToken token = _spriteRenderCts.Token;
+        byte[] sourcePixels = _spriteSourcePixels;
+        int sourceWidth = _spriteSourceWidth;
+        int sourceHeight = _spriteSourceHeight;
+
+        _ = RenderSpriteBitmapAsync(sourcePixels, sourceWidth, sourceHeight, targetWidth, targetHeight, token);
+    }
+
+    private async Task RenderSpriteBitmapAsync(
+        byte[] sourcePixels,
+        int sourceWidth,
+        int sourceHeight,
+        int targetWidth,
+        int targetHeight,
+        CancellationToken token)
+    {
+        byte[] scaled;
+        try
+        {
+            scaled = await Task.Run(() =>
+            {
+                byte[] localScaled = new byte[targetWidth * targetHeight * 4];
+
+                for (int y = 0; y < targetHeight; y++)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        return localScaled;
+                    }
+
+                    int sy = Math.Min(sourceHeight - 1, (int)((y / (double)targetHeight) * sourceHeight));
+                    for (int x = 0; x < targetWidth; x++)
+                    {
+                        int sx = Math.Min(sourceWidth - 1, (int)((x / (double)targetWidth) * sourceWidth));
+                        int src = ((sy * sourceWidth) + sx) * 4;
+                        int dst = ((y * targetWidth) + x) * 4;
+                        localScaled[dst] = sourcePixels[src];
+                        localScaled[dst + 1] = sourcePixels[src + 1];
+                        localScaled[dst + 2] = sourcePixels[src + 2];
+                        localScaled[dst + 3] = sourcePixels[src + 3];
+                    }
+                }
+
+                return localScaled;
+            }, token);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (token.IsCancellationRequested ||
+            targetWidth != _spriteRenderedWidth ||
+            targetHeight != _spriteRenderedHeight)
+        {
+            return;
+        }
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (token.IsCancellationRequested ||
+                targetWidth != _spriteRenderedWidth ||
+                targetHeight != _spriteRenderedHeight)
+            {
+                return;
+            }
+
+            _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
+            using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
+            stream.Position = 0;
+            stream.Write(scaled, 0, scaled.Length);
+            _spriteBitmap.Invalidate();
+            SpriteImage.Source = _spriteBitmap;
+        });
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -25,9 +25,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private WriteableBitmap? _checkerBitmap;
     private byte[]? _checkerPixels;
 
+    private byte[]? _spriteSourcePixels;
     private int _spriteSourceWidth;
     private int _spriteSourceHeight;
-    private bool _checkerboardNeedsRefresh = true;
+    private int _spriteRenderedWidth = -1;
+    private int _spriteRenderedHeight = -1;
+    private WriteableBitmap? _spriteBitmap;
 
     public FrameCoordinateEditor()
     {
@@ -57,9 +60,18 @@ public sealed partial class FrameCoordinateEditor : UserControl
         StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
         using IRandomAccessStream stream = await file.OpenReadAsync();
         BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
+        PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            new BitmapTransform(),
+            ExifOrientationMode.IgnoreExifOrientation,
+            ColorManagementMode.DoNotColorManage);
+
+        _spriteSourcePixels = pixelData.DetachPixelData();
         _spriteSourceWidth = (int)decoder.PixelWidth;
         _spriteSourceHeight = (int)decoder.PixelHeight;
-        SpriteImage.Source = new BitmapImage(new Uri(uri));
+        _spriteRenderedWidth = -1;
+        _spriteRenderedHeight = -1;
         UpdateVisuals();
     }
 
@@ -77,11 +89,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double axisX = centerX + _pan.X;
         double axisY = centerY + _pan.Y;
 
-        if (_checkerboardNeedsRefresh)
-        {
-            UpdateCheckerboard(canvasWidth, canvasHeight);
-            _checkerboardNeedsRefresh = false;
-        }
+        UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
 
         XAxis.Width = canvasWidth;
         Canvas.SetLeft(XAxis, 0);
@@ -93,6 +101,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         double spriteWidth = Math.Max(1.0, _spriteSourceWidth * _zoom);
         double spriteHeight = Math.Max(1.0, _spriteSourceHeight * _zoom);
+        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
@@ -104,7 +113,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
     }
 
-    private void UpdateCheckerboard(double canvasWidth, double canvasHeight)
+    private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
     {
         int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
         int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
@@ -121,14 +130,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
             _checkerPixels = new byte[byteCount];
         }
 
-        const int tileSize = 8;
+        double tileSize = 4.0 * _zoom;
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-            int tileY = y / tileSize;
+            int tileY = (int)Math.Floor((axisY - y) / tileSize);
             for (int x = 0; x < pixelWidth; x++)
             {
-                int tileX = x / tileSize;
+                int tileX = (int)Math.Floor((x - axisX) / tileSize);
                 byte color = ((tileX + tileY) & 1) == 0 ? (byte)30 : (byte)60;
 
                 _checkerPixels![idx++] = color;
@@ -143,9 +152,50 @@ public sealed partial class FrameCoordinateEditor : UserControl
         stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
         _checkerBitmap.Invalidate();
     }
+
+    private void UpdateSpriteBitmap(int targetWidth, int targetHeight)
+    {
+        if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
+        {
+            return;
+        }
+
+        if (_spriteBitmap != null && _spriteRenderedWidth == targetWidth && _spriteRenderedHeight == targetHeight)
+        {
+            SpriteImage.Source = _spriteBitmap;
+            return;
+        }
+
+        _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
+        byte[] scaled = new byte[targetWidth * targetHeight * 4];
+
+        for (int y = 0; y < targetHeight; y++)
+        {
+            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetHeight) * _spriteSourceHeight));
+            for (int x = 0; x < targetWidth; x++)
+            {
+                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetWidth) * _spriteSourceWidth));
+                int src = ((sy * _spriteSourceWidth) + sx) * 4;
+                int dst = ((y * targetWidth) + x) * 4;
+                scaled[dst] = _spriteSourcePixels[src];
+                scaled[dst + 1] = _spriteSourcePixels[src + 1];
+                scaled[dst + 2] = _spriteSourcePixels[src + 2];
+                scaled[dst + 3] = _spriteSourcePixels[src + 3];
+            }
+        }
+
+        using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
+        stream.Position = 0;
+        stream.Write(scaled, 0, scaled.Length);
+        _spriteBitmap.Invalidate();
+
+        SpriteImage.Source = _spriteBitmap;
+        _spriteRenderedWidth = targetWidth;
+        _spriteRenderedHeight = targetHeight;
+    }
+
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        _checkerboardNeedsRefresh = true;
         UpdateVisuals();
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,6 +1,5 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Dispatching;
@@ -41,15 +40,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _pendingSpriteHeight;
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
-    private bool _isUpdatingZoomControls;
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
-        ZoomSlider.Value = 100;
-        ZoomNumberBox.Value = 100;
         _spriteRenderTimer = DispatcherQueue.CreateTimer();
         _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(120);
         _spriteRenderTimer.IsRepeating = false;
@@ -121,8 +117,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double axisY = centerY + _pan.Y;
 
         UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
-        CheckerboardImage.Width = _checkerBitmap?.PixelWidth ?? canvasWidth;
-        CheckerboardImage.Height = _checkerBitmap?.PixelHeight ?? canvasHeight;
+        CheckerboardImage.Width = canvasWidth;
+        CheckerboardImage.Height = canvasHeight;
         Canvas.SetLeft(CheckerboardImage, 0);
         Canvas.SetTop(CheckerboardImage, 0);
 
@@ -145,7 +141,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteWidth / 2.0));
         Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteHeight / 2.0));
 
-        UpdateZoomControls();
+        ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
     }
 
     private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
@@ -373,56 +369,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _pan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
         UpdateVisuals();
         e.Handled = true;
-    }
-
-    private void UpdateZoomControls()
-    {
-        if (_isUpdatingZoomControls)
-        {
-            return;
-        }
-
-        _isUpdatingZoomControls = true;
-        double zoomPercent = Math.Round(_zoom * 100);
-        ZoomSlider.Value = zoomPercent;
-        ZoomNumberBox.Value = zoomPercent;
-        _isUpdatingZoomControls = false;
-    }
-
-    private void ZoomSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
-    {
-        if (_isUpdatingZoomControls)
-        {
-            return;
-        }
-
-        float newZoom = Math.Clamp((float)e.NewValue / 100.0f, MinZoom, MaxZoom);
-        if (Math.Abs(newZoom - _zoom) < 0.0001f)
-        {
-            return;
-        }
-
-        _zoom = newZoom;
-        _lastInteractionUtc = DateTime.UtcNow;
-        UpdateVisuals();
-    }
-
-    private void ZoomNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
-    {
-        if (_isUpdatingZoomControls || double.IsNaN(sender.Value))
-        {
-            return;
-        }
-
-        float newZoom = Math.Clamp((float)sender.Value / 100.0f, MinZoom, MaxZoom);
-        if (Math.Abs(newZoom - _zoom) < 0.0001f)
-        {
-            return;
-        }
-
-        _zoom = newZoom;
-        _lastInteractionUtc = DateTime.UtcNow;
-        UpdateVisuals();
     }
 
     private void CenterOriginButton_Click(object sender, RoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.IO;
@@ -25,12 +26,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private WriteableBitmap? _checkerBitmap;
     private byte[]? _checkerPixels;
 
-    private byte[]? _spriteSourcePixels;
     private int _spriteSourceWidth;
     private int _spriteSourceHeight;
-    private int _spriteRenderedWidth = -1;
-    private int _spriteRenderedHeight = -1;
-    private WriteableBitmap? _spriteBitmap;
+    private bool _checkerboardNeedsRefresh = true;
 
     public FrameCoordinateEditor()
     {
@@ -60,18 +58,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
         StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
         using IRandomAccessStream stream = await file.OpenReadAsync();
         BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
-        PixelDataProvider pixelData = await decoder.GetPixelDataAsync(
-            BitmapPixelFormat.Bgra8,
-            BitmapAlphaMode.Premultiplied,
-            new BitmapTransform(),
-            ExifOrientationMode.IgnoreExifOrientation,
-            ColorManagementMode.DoNotColorManage);
-
-        _spriteSourcePixels = pixelData.DetachPixelData();
         _spriteSourceWidth = (int)decoder.PixelWidth;
         _spriteSourceHeight = (int)decoder.PixelHeight;
-        _spriteRenderedWidth = -1;
-        _spriteRenderedHeight = -1;
+        SpriteImage.Source = new BitmapImage(new Uri(uri));
+        RenderOptions.SetBitmapInterpolationMode(SpriteImage, BitmapInterpolationMode.NearestNeighbor);
         UpdateVisuals();
     }
 
@@ -89,7 +79,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double axisX = centerX + _pan.X;
         double axisY = centerY + _pan.Y;
 
-        UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
+        if (_checkerboardNeedsRefresh)
+        {
+            UpdateCheckerboard(canvasWidth, canvasHeight);
+            _checkerboardNeedsRefresh = false;
+        }
 
         XAxis.Width = canvasWidth;
         Canvas.SetLeft(XAxis, 0);
@@ -101,7 +95,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         double spriteWidth = Math.Max(1.0, _spriteSourceWidth * _zoom);
         double spriteHeight = Math.Max(1.0, _spriteSourceHeight * _zoom);
-        UpdateSpriteBitmap(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
@@ -113,7 +106,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         ZoomTextBlock.Text = $"Zoom: {(int)Math.Round(_zoom * 100)}%";
     }
 
-    private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
+    private void UpdateCheckerboard(double canvasWidth, double canvasHeight)
     {
         int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
         int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
@@ -130,14 +123,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
             _checkerPixels = new byte[byteCount];
         }
 
-        double tileSize = 4.0 * _zoom;
+        const int tileSize = 8;
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-            int tileY = (int)Math.Floor((axisY - y) / tileSize);
+            int tileY = y / tileSize;
             for (int x = 0; x < pixelWidth; x++)
             {
-                int tileX = (int)Math.Floor((x - axisX) / tileSize);
+                int tileX = x / tileSize;
                 byte color = ((tileX + tileY) & 1) == 0 ? (byte)30 : (byte)60;
 
                 _checkerPixels![idx++] = color;
@@ -152,49 +145,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
         _checkerBitmap.Invalidate();
     }
-
-    private void UpdateSpriteBitmap(int targetWidth, int targetHeight)
+    private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        if (_spriteSourcePixels == null || _spriteSourceWidth <= 0 || _spriteSourceHeight <= 0)
-        {
-            return;
-        }
-
-        if (_spriteBitmap != null && _spriteRenderedWidth == targetWidth && _spriteRenderedHeight == targetHeight)
-        {
-            SpriteImage.Source = _spriteBitmap;
-            return;
-        }
-
-        _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
-        byte[] scaled = new byte[targetWidth * targetHeight * 4];
-
-        for (int y = 0; y < targetHeight; y++)
-        {
-            int sy = Math.Min(_spriteSourceHeight - 1, (int)((y / (double)targetHeight) * _spriteSourceHeight));
-            for (int x = 0; x < targetWidth; x++)
-            {
-                int sx = Math.Min(_spriteSourceWidth - 1, (int)((x / (double)targetWidth) * _spriteSourceWidth));
-                int src = ((sy * _spriteSourceWidth) + sx) * 4;
-                int dst = ((y * targetWidth) + x) * 4;
-                scaled[dst] = _spriteSourcePixels[src];
-                scaled[dst + 1] = _spriteSourcePixels[src + 1];
-                scaled[dst + 2] = _spriteSourcePixels[src + 2];
-                scaled[dst + 3] = _spriteSourcePixels[src + 3];
-            }
-        }
-
-        using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
-        stream.Position = 0;
-        stream.Write(scaled, 0, scaled.Length);
-        _spriteBitmap.Invalidate();
-
-        SpriteImage.Source = _spriteBitmap;
-        _spriteRenderedWidth = targetWidth;
-        _spriteRenderedHeight = targetHeight;
+        _checkerboardNeedsRefresh = true;
+        UpdateVisuals();
     }
-
-    private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e) => UpdateVisuals();
 
     private void CoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
     {

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -295,13 +295,11 @@
 
                         <!-- Frame Panel (hidden by default) -->
                         <Grid x:Name="FramePanel" Visibility="Collapsed">
-                            
-                            <StackPanel x:Name="FrameDetailPanel" Spacing="10" Padding="20 14 20 20" MaxWidth="1000">
-
-                                <local:FrameCoordinateEditor x:Name="FrameCoordinateEditorControl"/>
-
-                            </StackPanel>
-                            
+                            <Grid x:Name="FrameDetailPanel" Padding="20 14 20 20">
+                                <local:FrameCoordinateEditor x:Name="FrameCoordinateEditorControl"
+                                                             HorizontalAlignment="Stretch"
+                                                             VerticalAlignment="Stretch"/>
+                            </Grid>
                         </Grid>
 
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1435,7 +1435,7 @@ namespace FramesToMMSpriteResources
                         currentConfigs.Add(programConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs[int.Parse(selectedNodeName)]);
                     }
 
-                    _ = FrameCoordinateEditorControl.SetSpriteImageUriAsync("ms-appx:///Assets/yoshi-000.png");
+                    _ = FrameCoordinateEditorControl.SetSpriteImageUriAsync(@"C:\Users\katon\GitHub\sprite-rips-to-mm-sprite-resources\Assets\NSMBU\V_Yoshi\raw\Idle\yoshi-000.png");
                     FrameCoordinateEditorControl.SpritePosition = Vector2.Zero;
 
 


### PR DESCRIPTION
### Motivation
- The frame coordinate editor used a fixed square base size for sprite previews which squished non-1:1 images instead of showing their true pixel dimensions.
- The intent is to preview sprites at a pixel-accurate scale and preserve aspect ratio when zooming.

### Description
- Removed the fixed `SpriteBaseSize` and size the preview using the source image pixel dimensions multiplied by `_zoom` (`_spriteSourceWidth * _zoom` and `_spriteSourceHeight * _zoom`).
- Replaced `UpdateSpriteBitmap(int targetSize)` with `UpdateSpriteBitmap(int targetWidth, int targetHeight)` and updated the pixel-scaling loop to produce non-square bitmaps correctly.
- Replaced single cached `_spriteRenderedSize` with separate `_spriteRenderedWidth` and `_spriteRenderedHeight` so cache invalidation works when either dimension changes.
- Updated `SpriteImage.Width`/`Height` and its canvas positioning to use the computed width and height so previews maintain the source aspect ratio.

### Testing
- Attempted `dotnet build FramesToMMSpriteResources.slnx` which could not run in this environment because `dotnet` is not installed, so no automated build/test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee96dfc9cc8327892a5e1e7d243d23)