### PR TITLE
Defer frame editor updates until sprite load completes and cancel stale loads

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -42,6 +42,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
     private bool _isUpdatingZoomControls;
+    private int _spriteLoadVersion;
 
     public FrameCoordinateEditor()
     {
@@ -58,7 +59,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
             _spriteRenderTimer.Stop();
             StartSpriteBitmapRender(_pendingSpriteWidth, _pendingSpriteHeight);
         };
-        _ = SetSpriteImageUriAsync("ms-appx:///Assets/icon.png");
         UpdateVisuals();
     }
 
@@ -76,8 +76,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public event Action<IntVector2>? SpritePositionChanged;
 
-    public async System.Threading.Tasks.Task SetSpriteImageUriAsync(string uri)
+    public async Task<bool> LoadSpriteImageAsync(string uri, IntVector2 spritePosition, CancellationToken cancellationToken = default)
     {
+        int loadVersion = Interlocked.Increment(ref _spriteLoadVersion);
+
         StorageFile file;
         if (Path.IsPathRooted(uri))
         {
@@ -96,6 +98,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
             ExifOrientationMode.IgnoreExifOrientation,
             ColorManagementMode.DoNotColorManage);
 
+        if (cancellationToken.IsCancellationRequested || loadVersion != _spriteLoadVersion)
+        {
+            return false;
+        }
+
         _spriteSourcePixels = pixelData.DetachPixelData();
         _spriteSourceWidth = (int)decoder.PixelWidth;
         _spriteSourceHeight = (int)decoder.PixelHeight;
@@ -103,6 +110,23 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _spriteRenderedHeight = -1;
         _spriteRenderCts?.Cancel();
         _spriteRenderTimer.Stop();
+        SpritePosition = spritePosition;
+        UpdateVisuals();
+        return true;
+    }
+
+    public void UnloadSpriteImage()
+    {
+        Interlocked.Increment(ref _spriteLoadVersion);
+        _spriteRenderCts?.Cancel();
+        _spriteRenderTimer.Stop();
+        _spriteSourcePixels = null;
+        _spriteSourceWidth = 0;
+        _spriteSourceHeight = 0;
+        _spriteRenderedWidth = -1;
+        _spriteRenderedHeight = -1;
+        _spriteBitmap = null;
+        SpriteImage.Source = null;
         UpdateVisuals();
     }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Windows.ApplicationModel;
@@ -151,6 +152,7 @@ namespace FramesToMMSpriteResources
         private string _lastValidBackgroundColor = "";
 
         MediaPlayer player = new();
+        CancellationTokenSource? _frameEditorLoadCts;
 
         int fadeOutMs = 50;
         int fadeInMs = 100;
@@ -1117,7 +1119,10 @@ namespace FramesToMMSpriteResources
                     {
 
                         //await Task.Delay(30);
-                        
+                        if (panel == FramePanel)
+                        {
+                            UnloadFrameEditorImage();
+                        }
                         panel.Visibility = Visibility.Collapsed;
                     }
                     
@@ -1145,6 +1150,10 @@ namespace FramesToMMSpriteResources
             {
                 if (!sameDepth)
                 {
+                    if (panel == FramePanel)
+                    {
+                        UnloadFrameEditorImage();
+                    }
                     panel.Visibility = Visibility.Collapsed;
                 }
                 panel.Opacity = 1.0;
@@ -1456,11 +1465,7 @@ namespace FramesToMMSpriteResources
 
                     string framePath = Path.Combine(gameThemePath, subjectName, "raw", animationName, frameConfig.Name) + ".png";
 
-                    _ = FrameCoordinateEditorControl.SetSpriteImageUriAsync($@"{framePath}");
-
-                    
-
-                    FrameCoordinateEditorControl.SpritePosition = frameConfig.Offset;
+                    _ = LoadFrameEditorImageAsync(framePath, frameConfig.Offset);
 
                     FrameCoordinateEditorControl.SpritePositionChanged += SpriteOffset_ValueChanged;
 
@@ -1475,6 +1480,34 @@ namespace FramesToMMSpriteResources
 
 
 
+        }
+
+        private void UnloadFrameEditorImage()
+        {
+            _frameEditorLoadCts?.Cancel();
+            _frameEditorLoadCts?.Dispose();
+            _frameEditorLoadCts = null;
+            FrameCoordinateEditorControl.UnloadSpriteImage();
+        }
+
+        private async Task LoadFrameEditorImageAsync(string framePath, IntVector2 spritePosition)
+        {
+            _frameEditorLoadCts?.Cancel();
+            _frameEditorLoadCts?.Dispose();
+            _frameEditorLoadCts = new CancellationTokenSource();
+            CancellationToken cancellationToken = _frameEditorLoadCts.Token;
+
+            try
+            {
+                await FrameCoordinateEditorControl.LoadSpriteImageAsync(framePath, spritePosition, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                SetInfoBar(InfoBarSeverity.Error, "Could not load frame image", ex.Message, false);
+            }
         }
 
         private void DetachAllPanelEvents()


### PR DESCRIPTION
### Motivation
- Prevent the frame coordinate controls from being set before the sprite image is fully decoded so UI values reflect the actual loaded image.
- Cancel in-flight image loads when the user selects another frame to avoid stale UI updates, and unload the image when the frame editor panel is collapsed to free resources.

### Description
- Replaced the old immediate image setter with `LoadSpriteImageAsync(string uri, IntVector2 spritePosition, CancellationToken)` in `FrameCoordinateEditor` that applies `SpritePosition` only after the decode finishes and returns success/failure.
- Introduced a load-version guard (`_spriteLoadVersion`) and used `Interlocked.Increment` to avoid stale results from earlier loads and to provide a simple cancellation/versioning mechanism.
- Added `UnloadSpriteImage()` in `FrameCoordinateEditor` to cancel pending work and clear sprite data and the displayed `SpriteImage`.
- Updated `MainWindow` to manage per-selection cancellation with `_frameEditorLoadCts`, call the new `LoadFrameEditorImageAsync` helper for frame selection, and call `UnloadFrameEditorImage()` when the Frame panel is collapsed (both animated and non-animated collapse paths).

### Testing
- Attempted to run `dotnet build FramesToMMSpriteResources.slnx`, but the `dotnet` SDK is not available in this environment so the build could not be executed (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef52ce896c832797dcf87d5f47c8ef)