### PR TITLE
Optimize frame switching with cached sprite bitmaps

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -21,7 +21,7 @@
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
                         PointerExited="CoordinateCanvas_PointerReleased">
                 <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
-                <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False"/>
+                <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" RenderOptions.BitmapInterpolationMode="NearestNeighbor"/>
                 <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                 <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
             </Canvas>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -21,7 +21,7 @@
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
                         PointerExited="CoordinateCanvas_PointerReleased">
                 <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
-                <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" RenderOptions.BitmapInterpolationMode="NearestNeighbor"/>
+                <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" />
                 <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
                 <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
             </Canvas>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -23,7 +23,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private WriteableBitmap? _checkerBitmap;
     private byte[]? _checkerPixels;
 
-    private SpriteFrame? spriteFrame;
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
     private bool _isUpdatingZoomControls;
@@ -52,16 +51,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public event Action<IntVector2>? SpritePositionChanged;
 
-    public void SetSpriteImage(SpriteFrame spriteFrame)
+    public void SetSpriteImage(WriteableBitmap writeableBitmap)
     {
-        this.spriteFrame = spriteFrame;
-        SpriteImage.Source = spriteFrame.GetOrCreateSourceBitmap();
+        SpriteImage.Source = writeableBitmap;
         UpdateVisuals();
     }
 
     public void UnloadSprite()
     {
-        spriteFrame = null;
         SpriteImage.Source = null;
         //UpdateVisuals();
     }
@@ -95,10 +92,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Canvas.SetTop(YAxis, 0);
 
 
-        if (spriteFrame == null) return;
+        if (SpriteImage.Source == null) return;
 
-        double spriteWidth = Math.Max(1.0, spriteFrame.Size.X * _zoom);
-        double spriteHeight = Math.Max(1.0, spriteFrame.Size.Y * _zoom);
+        double spriteWidth = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap).PixelWidth * _zoom);
+        double spriteHeight = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap).PixelHeight * _zoom);
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
@@ -297,13 +294,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void ALignDownButton_Click(object sender, RoutedEventArgs e)
     {
         VectorXTextBox.Value = 0;
-        VectorYTextBox.Value = spriteFrame.Size.Y / 2;
+        VectorYTextBox.Value = (SpriteImage.Source as WriteableBitmap).PixelHeight / 2;
     }
 
     private void ALignTopLeftButton_Click(object sender, RoutedEventArgs e)
     {
-        VectorXTextBox.Value = (spriteFrame.Size.X / 2);
-        VectorYTextBox.Value = -(spriteFrame.Size.Y / 2);
+        VectorXTextBox.Value = ((SpriteImage.Source as WriteableBitmap).PixelWidth / 2);
+        VectorYTextBox.Value = -((SpriteImage.Source as WriteableBitmap).PixelHeight / 2);
     }
 
     private void ALignCenterButton_Click(object sender, RoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,16 +3,10 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Dispatching;
 using System;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
-using System.Threading;
-using System.Threading.Tasks;
-using Windows.Graphics.Imaging;
-using Windows.Storage;
-using Windows.Storage.Streams;
 
 namespace FramesToMMSpriteResources;
 
@@ -30,13 +24,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private byte[]? _checkerPixels;
 
     private SpriteFrame? spriteFrame;
-    private int _spriteRenderedWidth = -1;
-    private int _spriteRenderedHeight = -1;
-    private WriteableBitmap? _spriteBitmap;
-    private CancellationTokenSource? _spriteRenderCts;
-    private readonly DispatcherQueueTimer _spriteRenderTimer;
-    private int _pendingSpriteWidth;
-    private int _pendingSpriteHeight;
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
     private bool _isUpdatingZoomControls;
@@ -48,15 +35,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         VectorYTextBox.Value = 0;
         ZoomSlider.Value = 100;
         ZoomNumberBox.Value = 100;
-        _spriteRenderTimer = DispatcherQueue.CreateTimer();
-        _spriteRenderTimer.Interval = TimeSpan.FromMilliseconds(120);
-        _spriteRenderTimer.IsRepeating = false;
-        _spriteRenderTimer.Tick += (_, _) =>
-        {
-            _spriteRenderTimer.Stop();
-            StartSpriteBitmapRender(_pendingSpriteWidth, _pendingSpriteHeight);
-        };
-
         UpdateVisuals();
     }
 
@@ -76,24 +54,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void SetSpriteImage(SpriteFrame spriteFrame)
     {
-
-
         this.spriteFrame = spriteFrame;
-        _spriteRenderedWidth = -1;
-        _spriteRenderedHeight = -1;
-        _spriteRenderCts?.Cancel();
-        _spriteRenderTimer.Stop();
+        SpriteImage.Source = spriteFrame.GetOrCreateSourceBitmap();
         UpdateVisuals();
     }
 
     public void UnloadSprite()
     {
-        _spriteRenderCts?.Cancel();
-        _spriteRenderTimer.Stop();
         spriteFrame = null;
-        _spriteRenderedWidth = -1;
-        _spriteRenderedHeight = -1;
-        _spriteBitmap = null;
         SpriteImage.Source = null;
         //UpdateVisuals();
     }
@@ -131,7 +99,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         double spriteWidth = Math.Max(1.0, spriteFrame.Size.X * _zoom);
         double spriteHeight = Math.Max(1.0, spriteFrame.Size.Y * _zoom);
-        RequestSpriteBitmapUpdate(Math.Max(1, (int)Math.Round(spriteWidth)), Math.Max(1, (int)Math.Round(spriteHeight)));
 
         double spriteCanvasX = axisX + (_spritePosition.X * _zoom);
         double spriteCanvasY = axisY - (_spritePosition.Y * _zoom);
@@ -183,120 +150,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         stream.Position = 0;
         stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
         _checkerBitmap.Invalidate();
-    }
-
-    private void RequestSpriteBitmapUpdate(int targetWidth, int targetHeight)
-    {
-        if (spriteFrame.SpriteSourcePixels == null || spriteFrame.Size.X <= 0 || spriteFrame.Size.Y <= 0)
-        {
-            return;
-        }
-
-        if (_spriteBitmap != null && _spriteRenderedWidth == targetWidth && _spriteRenderedHeight == targetHeight)
-        {
-            SpriteImage.Source = _spriteBitmap;
-            return;
-        }
-
-        _spriteRenderedWidth = targetWidth;
-        _spriteRenderedHeight = targetHeight;
-        _pendingSpriteWidth = targetWidth;
-        _pendingSpriteHeight = targetHeight;
-
-        _spriteRenderCts?.Cancel();
-        _spriteRenderTimer.Stop();
-        _spriteRenderTimer.Start();
-    }
-
-    private void StartSpriteBitmapRender(int targetWidth, int targetHeight)
-    {
-        if (spriteFrame.SpriteSourcePixels == null || spriteFrame.Size.X <= 0 || spriteFrame.Size.Y <= 0)
-        {
-            return;
-        }
-
-        if (_isDragging || (DateTime.UtcNow - _lastInteractionUtc).TotalMilliseconds < 120)
-        {
-            _spriteRenderTimer.Stop();
-            _spriteRenderTimer.Start();
-            return;
-        }
-
-        _spriteRenderCts = new CancellationTokenSource();
-        CancellationToken token = _spriteRenderCts.Token;
-        byte[] sourcePixels = spriteFrame.SpriteSourcePixels;
-        int sourceWidth = spriteFrame.Size.X;
-        int sourceHeight = spriteFrame.Size.Y;
-
-        _ = RenderSpriteBitmapAsync(sourcePixels, sourceWidth, sourceHeight, targetWidth, targetHeight, token);
-    }
-
-    private async Task RenderSpriteBitmapAsync(
-        byte[] sourcePixels,
-        int sourceWidth,
-        int sourceHeight,
-        int targetWidth,
-        int targetHeight,
-        CancellationToken token)
-    {
-        byte[] scaled;
-        try
-        {
-            scaled = await Task.Run(() =>
-            {
-                byte[] localScaled = new byte[targetWidth * targetHeight * 4];
-
-                for (int y = 0; y < targetHeight; y++)
-                {
-                    if (token.IsCancellationRequested)
-                    {
-                        return localScaled;
-                    }
-
-                    int sy = Math.Min(sourceHeight - 1, (int)((y / (double)targetHeight) * sourceHeight));
-                    for (int x = 0; x < targetWidth; x++)
-                    {
-                        int sx = Math.Min(sourceWidth - 1, (int)((x / (double)targetWidth) * sourceWidth));
-                        int src = ((sy * sourceWidth) + sx) * 4;
-                        int dst = ((y * targetWidth) + x) * 4;
-                        localScaled[dst] = sourcePixels[src];
-                        localScaled[dst + 1] = sourcePixels[src + 1];
-                        localScaled[dst + 2] = sourcePixels[src + 2];
-                        localScaled[dst + 3] = sourcePixels[src + 3];
-                    }
-                }
-
-                return localScaled;
-            }, token);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
-
-        if (token.IsCancellationRequested ||
-            targetWidth != _spriteRenderedWidth ||
-            targetHeight != _spriteRenderedHeight)
-        {
-            return;
-        }
-
-        DispatcherQueue.TryEnqueue(() =>
-        {
-            if (token.IsCancellationRequested ||
-                targetWidth != _spriteRenderedWidth ||
-                targetHeight != _spriteRenderedHeight)
-            {
-                return;
-            }
-
-            _spriteBitmap = new WriteableBitmap(targetWidth, targetHeight);
-            using Stream stream = _spriteBitmap.PixelBuffer.AsStream();
-            stream.Position = 0;
-            stream.Write(scaled, 0, scaled.Length);
-            _spriteBitmap.Invalidate();
-            SpriteImage.Source = _spriteBitmap;
-        });
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -138,42 +139,13 @@ namespace FramesToMMSpriteResources
     public class AnimationSpriteFrame
     {
         public string Name;
-        public List<SpriteFrame> SpriteFrames = [];
+        public List<WriteableBitmap> WriteableBitmaps = [];
         
         public AnimationSpriteFrame() { }
-        public AnimationSpriteFrame(string name, List<SpriteFrame> spriteFrames)
+        public AnimationSpriteFrame(string name, List<WriteableBitmap> writeableBitmaps)
         {
             Name = name;
-            SpriteFrames = spriteFrames;
-        }
-    }
-
-    public class SpriteFrame
-    {
-        public byte[] SpriteSourcePixels;
-        public IntVector2 Size;
-        private WriteableBitmap? _sourceBitmap;
-
-        public SpriteFrame(byte[] spriteSourcePixels, IntVector2 size)
-        {
-            this.SpriteSourcePixels = spriteSourcePixels;
-            this.Size = size;
-        }
-
-        public WriteableBitmap GetOrCreateSourceBitmap()
-        {
-            if (_sourceBitmap != null)
-            {
-                return _sourceBitmap;
-            }
-
-            _sourceBitmap = new WriteableBitmap(Size.X, Size.Y);
-            using Stream stream = _sourceBitmap.PixelBuffer.AsStream();
-            stream.Position = 0;
-            stream.Write(SpriteSourcePixels, 0, SpriteSourcePixels.Length);
-            _sourceBitmap.Invalidate();
-
-            return _sourceBitmap;
+            WriteableBitmaps = writeableBitmaps;
         }
     }
 
@@ -213,7 +185,7 @@ namespace FramesToMMSpriteResources
             set
             {
                 _isWindowActive = value;
-                CheckForToggleProgramEditing();
+                CheckForAllowProgramEditing();
             }
         }
 
@@ -224,7 +196,7 @@ namespace FramesToMMSpriteResources
             set
             {
                 _isGenerating = value;
-                CheckForToggleProgramEditing();
+                CheckForAllowProgramEditing();
             }
         }
 
@@ -239,26 +211,72 @@ namespace FramesToMMSpriteResources
             }
         }
 
+        bool _isLoadingFrames = false;
+        public bool IsLoadingFrames
+        {
+            get => _isLoadingFrames;
+            set
+            {
+                _isLoadingFrames = value;
+                CheckForAllowFrameEditing();
+            }
+        }
+
+        void CheckForAllowFrameEditing()
+        {
+            if (!_isLoadingFrames)
+            {
+                FramesLoadingBorder.Child.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                FramesLoadingBorder.Child.Visibility = Visibility.Visible;
+            }
+
+            if (!_isGenerating && !_isLoadingFrames && _isWindowActive)
+            {
+                FramesLoadingBorder.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                FramesLoadingBorder.Visibility = Visibility.Visible;
+            }
+            
+        }
+
         void CheckForAllowGenerating()
         {
             bool isEnabled = (_isWindowActive && !_isGenerating && _isEnoughFrames);
-            CanGenerate(isEnabled);
+
+            ReduceFileSizeCheckBox.IsEnabled = isEnabled;
+            GenerateButton.IsEnabled = isEnabled;
+            if (isEnabled)
+            {
+                ReduceFileSizeCheckBoxTexts.Opacity = 1;
+            }
+            else
+            {
+                ReduceFileSizeCheckBoxTexts.Opacity = 0.5;
+            }
         }
 
-        void CheckForToggleProgramEditing()
+        void CheckForAllowProgramEditing()
         {
             bool isEnabled = (_isWindowActive && !_isGenerating);
-            ToggleProgramEditing(isEnabled);
-        }
 
-        void ToggleProgramEditing(bool isEnabled)
-        {
             ControlEnabler.IsEnabled = isEnabled;
             HeaderBreadcrumbBar.IsEnabled = isEnabled;
             TreeViewControl.IsEnabled = isEnabled;
             SettingsToggleButton.IsEnabled = isEnabled;
             CheckForAllowGenerating();
+            CheckForAllowFrameEditing();
         }
+
+
+
+
+
+    
 
         public ObservableCollection<string> BreadcrumbItems { get; } = new();
 
@@ -417,8 +435,7 @@ namespace FramesToMMSpriteResources
             else
             {
                 IsWindowActive = false;
-                FramesLoadingBorder.Visibility = Visibility.Visible;
-                FramesLoadingBorder.Child.Visibility = Visibility.Collapsed;
+
 
                 ReduceFileSizeCheckBox.Click -= ReduceFileSizeCheckBox_Click;
                 WorkingPathTextBox.TextChanged -= WorkingPathTextBox_LostFocus;
@@ -1057,19 +1074,7 @@ namespace FramesToMMSpriteResources
             
         }
 
-        void CanGenerate(bool isEnabled)
-        {
-            ReduceFileSizeCheckBox.IsEnabled = isEnabled;
-            GenerateButton.IsEnabled = isEnabled;
-            if (isEnabled)
-            {
-                ReduceFileSizeCheckBoxTexts.Opacity = 1;
-            }
-            else
-            {
-                ReduceFileSizeCheckBoxTexts.Opacity = 0.5;
-            }
-        }
+   
 
 
         private static bool IsUsingGameThemes()
@@ -1281,7 +1286,7 @@ namespace FramesToMMSpriteResources
             selectedNode.IsSelected = true;
         }
 
-        private CancellationTokenSource? _loadFramesCts;
+    
 
         async void DisplayCorrectPanel(TreeViewNode node, bool animate = true, bool nowGenerated = false)
         {
@@ -1482,7 +1487,7 @@ namespace FramesToMMSpriteResources
 
                     if(animationName != animationSpriteFrame.Name)
                     {
-                        animationSpriteFrame.SpriteFrames = [];
+                        animationSpriteFrame.WriteableBitmaps = [];
                         animationSpriteFrame.Name = animationName;
                     }
 
@@ -1518,7 +1523,9 @@ namespace FramesToMMSpriteResources
                         currentConfigs.Add(programConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs[int.Parse(selectedNodeName)]);
                     }
 
-
+                    //TODO: BREAK ASYNC WHEN OUT OF FOCUS OR DIFFERENT ANIMATION SELECTED
+                    if (IsLoadingFrames) break;
+                    Debug.WriteLine("01ASD");
 
                     string gameThemePath;
                     if (usingGameThemes)
@@ -1532,11 +1539,15 @@ namespace FramesToMMSpriteResources
 
                     string animationPath = Path.Combine(gameThemePath, subjectName, "raw", animationName);
 
-                    if(animationSpriteFrame.SpriteFrames.Count == 0)
+                   
+
+                    if(animationSpriteFrame.WriteableBitmaps.Count == 0)
                     {
+                        IsLoadingFrames = true;
+
                         var tempAnimationSpriteFrame = new AnimationSpriteFrame(animationSpriteFrame.Name, []);
 
-                        FramesLoadingBorder.Visibility = Visibility.Visible;
+               
                         foreach (FrameConfig frameConfigInLoop in animationConfig.frameCongfigs)
                         {
                             string framePath = Path.Combine(animationPath, frameConfigInLoop.Name) + ".png";
@@ -1557,26 +1568,42 @@ namespace FramesToMMSpriteResources
                             var spriteSourceWidth = (int)decoder.PixelWidth;
                             var spriteSourceHeight = (int)decoder.PixelHeight;
 
-                            tempAnimationSpriteFrame.SpriteFrames.Add(new SpriteFrame(spriteSourcePixels, new IntVector2(spriteSourceWidth, spriteSourceHeight)));
+                            var sourceBitmap = new WriteableBitmap(spriteSourceWidth, spriteSourceHeight);
+                            using Stream streamWritible = sourceBitmap.PixelBuffer.AsStream();
+                            streamWritible.Position = 0;
+                            streamWritible.Write(spriteSourcePixels, 0, spriteSourcePixels.Length);
+                            sourceBitmap.Invalidate();
+
+                            tempAnimationSpriteFrame.WriteableBitmaps.Add(sourceBitmap);
                         }
 
-                        if(IsWindowActive)
-                            FramesLoadingBorder.Visibility = Visibility.Collapsed;
-                        else
-                            FramesLoadingBorder.Child.Visibility = Visibility.Collapsed;
-
                         animationSpriteFrame = tempAnimationSpriteFrame;
+
+                        var selectedNodeAfter = (TreeViewControl.SelectedNode.Content as TreeItem)!;
+
+                        if (selectedNodeAfter.Depth == ItemDepth.Frame)
+                        {
+                            frameName = selectedNodeAfter.Text;
+                            selectedIndex = int.Parse(frameName);
+                            frameConfig = animationConfig.frameCongfigs[selectedIndex];
+                        }
+                        
+                        IsLoadingFrames = false;
                     }
 
 
+                    if ((TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame)
+                    {
+                        FrameCoordinateEditorControl.SetSpriteImage(animationSpriteFrame.WriteableBitmaps[selectedIndex]);
 
-                    FrameCoordinateEditorControl.SetSpriteImage(animationSpriteFrame.SpriteFrames[selectedIndex]);
 
-                    
 
-                    FrameCoordinateEditorControl.SpritePosition = frameConfig.Offset;
 
-                    FrameCoordinateEditorControl.SpritePositionChanged += SpriteOffset_ValueChanged;
+                        FrameCoordinateEditorControl.SpritePosition = frameConfig.Offset;
+
+                        FrameCoordinateEditorControl.SpritePositionChanged += SpriteOffset_ValueChanged;
+                    }
+                        
 
 
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -151,11 +152,28 @@ namespace FramesToMMSpriteResources
     {
         public byte[] SpriteSourcePixels;
         public IntVector2 Size;
+        private WriteableBitmap? _sourceBitmap;
 
         public SpriteFrame(byte[] spriteSourcePixels, IntVector2 size)
         {
             this.SpriteSourcePixels = spriteSourcePixels;
             this.Size = size;
+        }
+
+        public WriteableBitmap GetOrCreateSourceBitmap()
+        {
+            if (_sourceBitmap != null)
+            {
+                return _sourceBitmap;
+            }
+
+            _sourceBitmap = new WriteableBitmap(Size.X, Size.Y);
+            using Stream stream = _sourceBitmap.PixelBuffer.AsStream();
+            stream.Position = 0;
+            stream.Write(SpriteSourcePixels, 0, SpriteSourcePixels.Length);
+            _sourceBitmap.Invalidate();
+
+            return _sourceBitmap;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Frame selection was slow because each selection or zoom path re-created resized pixel buffers on the CPU before presenting the image, causing noticeable delay in the canvas.
- The goal is to have decoded/ready bitmaps in memory so changing the displayed frame in `FrameCoordinateEditor` is an immediate source swap.

### Description
- Add a `WriteableBitmap` cache to `SpriteFrame` with `GetOrCreateSourceBitmap()` to materialize the decoded pixel buffer once and reuse it. (modified `MainWindow.xaml.cs`)
- Make `FrameCoordinateEditor.SetSpriteImage` assign the cached bitmap to `SpriteImage.Source` instead of scheduling CPU resampling, and remove the deferred async resampling/timer/state used for generating scaled buffers. (modified `FrameCoordinateEditor.xaml.cs`)
- Set the preview image interpolation to `NearestNeighbor` so pixel art remains crisp when scaled. (modified `FrameCoordinateEditor.xaml`)
- Clean up unused timers, tokens, fields and related using/imports that belonged to the old resampling pipeline. (modified `FrameCoordinateEditor.xaml.cs`)

### Testing
- Attempted to run `dotnet build FramesToMMSpriteResources.slnx`, but the environment lacks the `dotnet` SDK so the build could not be executed (`dotnet: command not found`).
- No other automated tests were available in this environment to run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9efb7714832794859fc167f494dd)