### PR TITLE
WASD nudging + 60FPS looping animation preview in FrameCoordinateEditor

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -1,7 +1,9 @@
 <UserControl
     x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    IsTabStop="True"
+    KeyDown="RootGrid_KeyDown">
 
     <Grid>
         <Grid.ColumnDefinitions>
@@ -10,7 +12,8 @@
         </Grid.ColumnDefinitions>
 
         <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
-            <Canvas x:Name="CoordinateCanvas"
+            <Grid>
+                <Canvas x:Name="CoordinateCanvas"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Background="Transparent"
@@ -20,11 +23,39 @@
                         PointerReleased="CoordinateCanvas_PointerReleased"
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"
                         PointerExited="CoordinateCanvas_PointerReleased">
-                <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
-                <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" />
-                <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-            </Canvas>
+                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
+                    <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" />
+                    <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                    <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                </Canvas>
+
+                <Border HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="12"
+                        Padding="8"
+                        CornerRadius="8"
+                        Background="#CC1E1E1E"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Animation Preview" FontSize="12" Opacity="0.9"/>
+                        <Grid Width="96" Height="96">
+                            <Rectangle Fill="#44000000"/>
+                            <Rectangle x:Name="PreviewXAxis"
+                                       Height="1"
+                                       Fill="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Opacity="0.8"
+                                       VerticalAlignment="Center"/>
+                            <Rectangle x:Name="PreviewYAxis"
+                                       Width="1"
+                                       Fill="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Opacity="0.8"
+                                       HorizontalAlignment="Center"/>
+                            <Image x:Name="AnimationPreviewImage" Stretch="None"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
         <ScrollView Grid.Column="1" Width="250" CornerRadius="0">

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -39,20 +39,26 @@
                         BorderThickness="1">
                     <StackPanel Spacing="6">
                         <TextBlock Text="Animation Preview" FontSize="12" Opacity="0.9"/>
-                        <Grid Width="96" Height="96">
-                            <Rectangle Fill="#44000000"/>
+                        <Canvas x:Name="AnimationPreviewCanvas"
+                                Width="96"
+                                Height="96"
+                                Background="#44000000"
+                                SizeChanged="AnimationPreviewCanvas_SizeChanged"
+                                PointerPressed="AnimationPreviewCanvas_PointerPressed"
+                                PointerMoved="AnimationPreviewCanvas_PointerMoved"
+                                PointerReleased="AnimationPreviewCanvas_PointerReleased"
+                                PointerExited="AnimationPreviewCanvas_PointerReleased"
+                                PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged">
                             <Rectangle x:Name="PreviewXAxis"
                                        Height="1"
                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
-                                       Opacity="0.8"
-                                       VerticalAlignment="Center"/>
+                                       Opacity="0.8"/>
                             <Rectangle x:Name="PreviewYAxis"
                                        Width="1"
                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
-                                       Opacity="0.8"
-                                       HorizontalAlignment="Center"/>
+                                       Opacity="0.8"/>
                             <Image x:Name="AnimationPreviewImage" Stretch="None"/>
-                        </Grid>
+                        </Canvas>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -3,7 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     IsTabStop="True"
-    KeyDown="RootGrid_KeyDown">
+    KeyDown="RootGrid_KeyDown"
+    KeyUp="RootGrid_KeyUp">
 
     <Grid>
         <Grid.ColumnDefinitions>
@@ -57,7 +58,7 @@
                                        Width="1"
                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
                                        Opacity="0.8"/>
-                            <Image x:Name="AnimationPreviewImage" Stretch="None"/>
+                            <Image x:Name="AnimationPreviewImage" Stretch="Fill"/>
                         </Canvas>
                     </StackPanel>
                 </Border>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -12,7 +12,7 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0" Background="{ThemeResource LayerFillColorDefaultBrush}">
+        <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0">
             <Grid>
                 <Canvas x:Name="CoordinateCanvas"
                         HorizontalAlignment="Stretch"
@@ -32,24 +32,25 @@
 
                 <Border HorizontalAlignment="Right"
                         VerticalAlignment="Top"
-                        Margin="12"
-                        Padding="8"
+                        Margin="10"
+                      
                         CornerRadius="8"
-                        Background="#CC1E1E1E"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                        BorderBrush="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
                         BorderThickness="1">
                     <StackPanel Spacing="6">
-                        <TextBlock Text="Animation Preview" FontSize="12" Opacity="0.9"/>
+                        
                         <Canvas x:Name="AnimationPreviewCanvas"
-                                Width="96"
-                                Height="96"
-                                Background="#44000000"
+                                Width="125"
+                                Height="150"
+                               Background="Transparent"
                                 SizeChanged="AnimationPreviewCanvas_SizeChanged"
                                 PointerPressed="AnimationPreviewCanvas_PointerPressed"
                                 PointerMoved="AnimationPreviewCanvas_PointerMoved"
                                 PointerReleased="AnimationPreviewCanvas_PointerReleased"
                                 PointerExited="AnimationPreviewCanvas_PointerReleased"
                                 PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged">
+                            <Image x:Name="AnimationPreviewImage" Stretch="Fill"/>
                             <Rectangle x:Name="PreviewXAxis"
                                        Height="1"
                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
@@ -58,7 +59,7 @@
                                        Width="1"
                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
                                        Opacity="0.8"/>
-                            <Image x:Name="AnimationPreviewImage" Stretch="Fill"/>
+                        
                         </Canvas>
                     </StackPanel>
                 </Border>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -41,15 +41,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _previewDragStartPointer;
     private Vector2 _previewDragStartPan;
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
-    private readonly DispatcherTimer _nudgeTimer = new DispatcherTimer();
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
         _previewTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _previewTimer.Tick += PreviewTimer_Tick;
-        _nudgeTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
-        _nudgeTimer.Tick += NudgeTimer_Tick;
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
         ZoomSlider.Value = 100;
@@ -370,10 +367,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         _heldNudgeKeys.Add(key);
         ApplyHeldNudgeKeys();
-        if (!_nudgeTimer.IsEnabled)
-        {
-            _nudgeTimer.Start();
-        }
         return true;
     }
 
@@ -385,10 +378,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _heldNudgeKeys.Remove(key);
-        if (_heldNudgeKeys.Count == 0)
-        {
-            _nudgeTimer.Stop();
-        }
         return true;
     }
 
@@ -558,16 +547,5 @@ public sealed partial class FrameCoordinateEditor : UserControl
                  (_heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ? 1 : 0);
 
         NudgeOffset(dx, dy);
-    }
-
-    private void NudgeTimer_Tick(object? sender, object e)
-    {
-        if (_heldNudgeKeys.Count == 0)
-        {
-            _nudgeTimer.Stop();
-            return;
-        }
-
-        ApplyHeldNudgeKeys();
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -41,12 +41,15 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _previewDragStartPointer;
     private Vector2 _previewDragStartPan;
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
+    private readonly DispatcherTimer _nudgeTimer = new DispatcherTimer();
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
         _previewTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _previewTimer.Tick += PreviewTimer_Tick;
+        _nudgeTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
+        _nudgeTimer.Tick += NudgeTimer_Tick;
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
         ZoomSlider.Value = 100;
@@ -367,6 +370,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         _heldNudgeKeys.Add(key);
         ApplyHeldNudgeKeys();
+        if (!_nudgeTimer.IsEnabled)
+        {
+            _nudgeTimer.Start();
+        }
         return true;
     }
 
@@ -378,6 +385,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _heldNudgeKeys.Remove(key);
+        if (_heldNudgeKeys.Count == 0)
+        {
+            _nudgeTimer.Stop();
+        }
         return true;
     }
 
@@ -547,5 +558,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
                  (_heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ? 1 : 0);
 
         NudgeOffset(dx, dy);
+    }
+
+    private void NudgeTimer_Tick(object? sender, object e)
+    {
+        if (_heldNudgeKeys.Count == 0)
+        {
+            _nudgeTimer.Stop();
+            return;
+        }
+
+        ApplyHeldNudgeKeys();
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -40,6 +40,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private bool _isPreviewDragging;
     private Vector2 _previewDragStartPointer;
     private Vector2 _previewDragStartPan;
+    private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
 
     public FrameCoordinateEditor()
     {
@@ -346,37 +347,51 @@ public sealed partial class FrameCoordinateEditor : UserControl
         VectorYTextBox.Value = 0;
     }
 
-    public bool TryHandleOffsetNudgeKey(Windows.System.VirtualKey key)
+    public void NudgeOffset(int dx, int dy)
     {
-        int nextX = _spritePosition.X;
-        int nextY = _spritePosition.Y;
-
-        switch (key)
+        if (dx == 0 && dy == 0)
         {
-            case Windows.System.VirtualKey.W:
-                nextY += 1;
-                break;
-            case Windows.System.VirtualKey.A:
-                nextX -= 1;
-                break;
-            case Windows.System.VirtualKey.S:
-                nextY -= 1;
-                break;
-            case Windows.System.VirtualKey.D:
-                nextX += 1;
-                break;
-            default:
-                return false;
+            return;
         }
 
-        VectorXTextBox.Value = nextX;
-        VectorYTextBox.Value = nextY;
+        VectorXTextBox.Value = _spritePosition.X + dx;
+        VectorYTextBox.Value = _spritePosition.Y + dy;
+    }
+
+    public bool HandleNudgeKeyDown(Windows.System.VirtualKey key)
+    {
+        if (!IsNudgeKey(key))
+        {
+            return false;
+        }
+
+        _heldNudgeKeys.Add(key);
+        ApplyHeldNudgeKeys();
+        return true;
+    }
+
+    public bool HandleNudgeKeyUp(Windows.System.VirtualKey key)
+    {
+        if (!IsNudgeKey(key))
+        {
+            return false;
+        }
+
+        _heldNudgeKeys.Remove(key);
         return true;
     }
 
     private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (TryHandleOffsetNudgeKey(e.Key))
+        if (HandleNudgeKeyDown(e.Key))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void RootGrid_KeyUp(object sender, KeyRoutedEventArgs e)
+    {
+        if (HandleNudgeKeyUp(e.Key))
         {
             e.Handled = true;
         }
@@ -514,5 +529,23 @@ public sealed partial class FrameCoordinateEditor : UserControl
         AnimationPreviewImage.RenderTransform = null;
         Canvas.SetLeft(AnimationPreviewImage, spriteCanvasX - (spriteWidth / 2.0));
         Canvas.SetTop(AnimationPreviewImage, spriteCanvasY - (spriteHeight / 2.0));
+    }
+
+    private static bool IsNudgeKey(Windows.System.VirtualKey key)
+    {
+        return key == Windows.System.VirtualKey.W ||
+               key == Windows.System.VirtualKey.A ||
+               key == Windows.System.VirtualKey.S ||
+               key == Windows.System.VirtualKey.D;
+    }
+
+    private void ApplyHeldNudgeKeys()
+    {
+        int dx = (_heldNudgeKeys.Contains(Windows.System.VirtualKey.D) ? 1 : 0) -
+                 (_heldNudgeKeys.Contains(Windows.System.VirtualKey.A) ? 1 : 0);
+        int dy = (_heldNudgeKeys.Contains(Windows.System.VirtualKey.W) ? 1 : 0) -
+                 (_heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ? 1 : 0);
+
+        NudgeOffset(dx, dy);
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -19,7 +19,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _dragStartPan;
     private bool _isDragging;
     private float _zoom = 1.0f;
-    private const float MinZoom = 0.3f;
+    private const float MinZoom = 0.2f;
     private const float MaxZoom = 18.0f;
     private WriteableBitmap? _checkerBitmap;
     private byte[]? _checkerPixels;
@@ -32,10 +32,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private IReadOnlyList<IntVector2> _previewOffsets = Array.Empty<IntVector2>();
     private int _previewFrameIndex;
     private int _previewTickCount;
-    private const int PreviewTicksPerFrame = 2;
+    private const int PreviewTicksPerFrame = 1;
     private Vector2 _previewPan = Vector2.Zero;
     private float _previewZoom = 1.0f;
-    private const float MinPreviewZoom = 0.25f;
+    private const float MinPreviewZoom = 0.1f;
     private const float MaxPreviewZoom = 12.0f;
     private bool _isPreviewDragging;
     private Vector2 _previewDragStartPointer;
@@ -80,8 +80,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewOffsets = offsets;
         _previewFrameIndex = 0;
         _previewTickCount = 0;
-        _previewPan = Vector2.Zero;
-        _previewZoom = 1.0f;
+ 
         UpdateAnimationPreviewFrame();
 
         if (_previewFrames.Count > 0)
@@ -311,7 +310,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void CenterOriginButton_Click(object sender, RoutedEventArgs e)
     {
         _pan = Vector2.Zero;
+        _previewPan = Vector2.Zero;
+        
         _lastInteractionUtc = DateTime.UtcNow;
+        UpdateAnimationPreviewFrame();
         UpdateVisuals();
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -2,8 +2,11 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Threading;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -26,10 +29,18 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private const int CheckerRenderScale = 1;
     private DateTime _lastInteractionUtc = DateTime.MinValue;
     private bool _isUpdatingZoomControls;
+    private readonly DispatcherTimer _previewTimer = new DispatcherTimer();
+    private IReadOnlyList<WriteableBitmap> _previewFrames = Array.Empty<WriteableBitmap>();
+    private IReadOnlyList<IntVector2> _previewOffsets = Array.Empty<IntVector2>();
+    private int _previewFrameIndex;
+    private int _previewTickCount;
+    private const int PreviewTicksPerFrame = 2;
 
     public FrameCoordinateEditor()
     {
         this.InitializeComponent();
+        _previewTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
+        _previewTimer.Tick += PreviewTimer_Tick;
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
         ZoomSlider.Value = 100;
@@ -57,10 +68,28 @@ public sealed partial class FrameCoordinateEditor : UserControl
         UpdateVisuals();
     }
 
+    public void SetAnimationPreviewFrames(IReadOnlyList<WriteableBitmap> frames, IReadOnlyList<IntVector2> offsets)
+    {
+        _previewFrames = frames;
+        _previewOffsets = offsets;
+        _previewFrameIndex = 0;
+        _previewTickCount = 0;
+        UpdateAnimationPreviewFrame();
+
+        if (_previewFrames.Count > 0)
+        {
+            _previewTimer.Start();
+        }
+        else
+        {
+            _previewTimer.Stop();
+        }
+    }
+
     public void UnloadSprite()
     {
         SpriteImage.Source = null;
-        //UpdateVisuals();
+        SetAnimationPreviewFrames(Array.Empty<WriteableBitmap>(), Array.Empty<IntVector2>());
     }
 
     private void UpdateVisuals()
@@ -156,6 +185,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void CoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        this.Focus(FocusState.Programmatic);
         var point = e.GetCurrentPoint(CoordinateCanvas);
         _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _dragStartPan = _pan;
@@ -307,5 +337,74 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         VectorXTextBox.Value = 0;
         VectorYTextBox.Value = 0;
+    }
+
+    private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        int nextX = _spritePosition.X;
+        int nextY = _spritePosition.Y;
+
+        switch (e.Key)
+        {
+            case Windows.System.VirtualKey.W:
+                nextY += 1;
+                break;
+            case Windows.System.VirtualKey.A:
+                nextX -= 1;
+                break;
+            case Windows.System.VirtualKey.S:
+                nextY -= 1;
+                break;
+            case Windows.System.VirtualKey.D:
+                nextX += 1;
+                break;
+            default:
+                return;
+        }
+
+        VectorXTextBox.Value = nextX;
+        VectorYTextBox.Value = nextY;
+        e.Handled = true;
+    }
+
+    private void PreviewTimer_Tick(object? sender, object e)
+    {
+        if (_previewFrames.Count == 0)
+        {
+            _previewTimer.Stop();
+            return;
+        }
+
+        _previewTickCount++;
+        if (_previewTickCount < PreviewTicksPerFrame)
+        {
+            return;
+        }
+
+        _previewTickCount = 0;
+        _previewFrameIndex = (_previewFrameIndex + 1) % _previewFrames.Count;
+        UpdateAnimationPreviewFrame();
+    }
+
+    private void UpdateAnimationPreviewFrame()
+    {
+        if (_previewFrames.Count == 0)
+        {
+            AnimationPreviewImage.Source = null;
+            return;
+        }
+
+        int frameIndex = Math.Clamp(_previewFrameIndex, 0, _previewFrames.Count - 1);
+        WriteableBitmap frame = _previewFrames[frameIndex];
+        IntVector2 offset = frameIndex < _previewOffsets.Count ? _previewOffsets[frameIndex] : new IntVector2(0, 0);
+
+        AnimationPreviewImage.Source = frame;
+        AnimationPreviewImage.Width = frame.PixelWidth;
+        AnimationPreviewImage.Height = frame.PixelHeight;
+        AnimationPreviewImage.RenderTransform = new TranslateTransform
+        {
+            X = offset.X,
+            Y = -offset.Y
+        };
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -2,9 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Xaml.Threading;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -35,6 +33,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _previewFrameIndex;
     private int _previewTickCount;
     private const int PreviewTicksPerFrame = 2;
+    private Vector2 _previewPan = Vector2.Zero;
+    private float _previewZoom = 1.0f;
+    private const float MinPreviewZoom = 0.25f;
+    private const float MaxPreviewZoom = 12.0f;
+    private bool _isPreviewDragging;
+    private Vector2 _previewDragStartPointer;
+    private Vector2 _previewDragStartPan;
 
     public FrameCoordinateEditor()
     {
@@ -74,6 +79,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewOffsets = offsets;
         _previewFrameIndex = 0;
         _previewTickCount = 0;
+        _previewPan = Vector2.Zero;
+        _previewZoom = 1.0f;
         UpdateAnimationPreviewFrame();
 
         if (_previewFrames.Count > 0)
@@ -339,12 +346,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
         VectorYTextBox.Value = 0;
     }
 
-    private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
+    public bool TryHandleOffsetNudgeKey(Windows.System.VirtualKey key)
     {
         int nextX = _spritePosition.X;
         int nextY = _spritePosition.Y;
 
-        switch (e.Key)
+        switch (key)
         {
             case Windows.System.VirtualKey.W:
                 nextY += 1;
@@ -359,11 +366,89 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 nextX += 1;
                 break;
             default:
-                return;
+                return false;
         }
 
         VectorXTextBox.Value = nextX;
         VectorYTextBox.Value = nextY;
+        return true;
+    }
+
+    private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (TryHandleOffsetNudgeKey(e.Key))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void AnimationPreviewCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateAnimationPreviewFrame();
+    }
+
+    private void AnimationPreviewCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(AnimationPreviewCanvas);
+        _previewDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        _previewDragStartPan = _previewPan;
+        _isPreviewDragging = true;
+        AnimationPreviewCanvas.CapturePointer(e.Pointer);
+        e.Handled = true;
+    }
+
+    private void AnimationPreviewCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isPreviewDragging)
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(AnimationPreviewCanvas);
+        var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        _previewPan = _previewDragStartPan + (currentPosition - _previewDragStartPointer);
+        UpdateAnimationPreviewFrame();
+        e.Handled = true;
+    }
+
+    private void AnimationPreviewCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        _isPreviewDragging = false;
+        AnimationPreviewCanvas.ReleasePointerCapture(e.Pointer);
+    }
+
+    private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(AnimationPreviewCanvas);
+        int wheelDelta = point.Properties.MouseWheelDelta;
+        if (wheelDelta == 0)
+        {
+            return;
+        }
+
+        float oldZoom = _previewZoom;
+        float zoomMultiplier = wheelDelta > 0 ? 1.1f : 0.9f;
+        float newZoom = Math.Clamp(oldZoom * zoomMultiplier, MinPreviewZoom, MaxPreviewZoom);
+        if (Math.Abs(newZoom - oldZoom) < 0.0001f)
+        {
+            return;
+        }
+
+        double centerX = AnimationPreviewCanvas.ActualWidth / 2.0;
+        double centerY = AnimationPreviewCanvas.ActualHeight / 2.0;
+        double oldAxisX = centerX + _previewPan.X;
+        double oldAxisY = centerY + _previewPan.Y;
+
+        double worldX = (point.Position.X - oldAxisX) / oldZoom;
+        double worldY = (oldAxisY - point.Position.Y) / oldZoom;
+
+        _previewZoom = newZoom;
+
+        double newAxisX = point.Position.X - (worldX * newZoom);
+        double newAxisY = point.Position.Y + (worldY * newZoom);
+        _previewPan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
+
+        UpdateAnimationPreviewFrame();
         e.Handled = true;
     }
 
@@ -398,13 +483,36 @@ public sealed partial class FrameCoordinateEditor : UserControl
         WriteableBitmap frame = _previewFrames[frameIndex];
         IntVector2 offset = frameIndex < _previewOffsets.Count ? _previewOffsets[frameIndex] : new IntVector2(0, 0);
 
-        AnimationPreviewImage.Source = frame;
-        AnimationPreviewImage.Width = frame.PixelWidth;
-        AnimationPreviewImage.Height = frame.PixelHeight;
-        AnimationPreviewImage.RenderTransform = new TranslateTransform
+        double canvasWidth = AnimationPreviewCanvas.ActualWidth;
+        double canvasHeight = AnimationPreviewCanvas.ActualHeight;
+        if (canvasWidth <= 0 || canvasHeight <= 0)
         {
-            X = offset.X,
-            Y = -offset.Y
-        };
+            return;
+        }
+
+        double centerX = canvasWidth / 2.0;
+        double centerY = canvasHeight / 2.0;
+        double axisX = centerX + _previewPan.X;
+        double axisY = centerY + _previewPan.Y;
+
+        PreviewXAxis.Width = canvasWidth;
+        Canvas.SetLeft(PreviewXAxis, 0);
+        Canvas.SetTop(PreviewXAxis, axisY - (PreviewXAxis.Height / 2.0));
+
+        PreviewYAxis.Height = canvasHeight;
+        Canvas.SetLeft(PreviewYAxis, axisX - (PreviewYAxis.Width / 2.0));
+        Canvas.SetTop(PreviewYAxis, 0);
+
+        double spriteWidth = Math.Max(1.0, frame.PixelWidth * _previewZoom);
+        double spriteHeight = Math.Max(1.0, frame.PixelHeight * _previewZoom);
+        double spriteCanvasX = axisX + (offset.X * _previewZoom);
+        double spriteCanvasY = axisY - (offset.Y * _previewZoom);
+
+        AnimationPreviewImage.Source = frame;
+        AnimationPreviewImage.Width = spriteWidth;
+        AnimationPreviewImage.Height = spriteHeight;
+        AnimationPreviewImage.RenderTransform = null;
+        Canvas.SetLeft(AnimationPreviewImage, spriteCanvasX - (spriteWidth / 2.0));
+        Canvas.SetTop(AnimationPreviewImage, spriteCanvasY - (spriteHeight / 2.0));
     }
 }

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2174,7 +2174,7 @@ namespace FramesToMMSpriteResources
                 TreeViewControl.SelectedNode != null &&
                 (TreeViewControl.SelectedNode.Content as TreeItem)?.Depth == ItemDepth.Frame;
 
-            if (isFrameEditorOpen && FrameCoordinateEditorControl.TryHandleOffsetNudgeKey(e.Key))
+            if (isFrameEditorOpen && FrameCoordinateEditorControl.HandleNudgeKeyDown(e.Key))
             {
                 e.Handled = true;
             }
@@ -2188,6 +2188,8 @@ namespace FramesToMMSpriteResources
             {
                 _isCtrlHeld = false;
             }
+
+            FrameCoordinateEditorControl.HandleNudgeKeyUp(e.Key);
         }
 
         private void ClearAllTreeItemSelections()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2166,6 +2166,17 @@ namespace FramesToMMSpriteResources
                 e.Key == Windows.System.VirtualKey.RightControl)
             {
                 _isCtrlHeld = true;
+                return;
+            }
+
+            bool isFrameEditorOpen =
+                FramePanel.Visibility == Visibility.Visible &&
+                TreeViewControl.SelectedNode != null &&
+                (TreeViewControl.SelectedNode.Content as TreeItem)?.Depth == ItemDepth.Frame;
+
+            if (isFrameEditorOpen && FrameCoordinateEditorControl.TryHandleOffsetNudgeKey(e.Key))
+            {
+                e.Handled = true;
             }
         }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1589,13 +1589,14 @@ namespace FramesToMMSpriteResources
                         }
                         
                         IsLoadingFrames = false;
+                        FrameCoordinateEditorControl.SetAnimationPreviewFrames(animationSpriteFrame.WriteableBitmaps, animationConfig.frameCongfigs.Select(frame => frame.Offset).ToList());
                     }
 
 
                     if ((TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame)
                     {
                         FrameCoordinateEditorControl.SetSpriteImage(animationSpriteFrame.WriteableBitmaps[selectedIndex]);
-                        FrameCoordinateEditorControl.SetAnimationPreviewFrames(animationSpriteFrame.WriteableBitmaps, animationConfig.frameCongfigs.Select(frame => frame.Offset).ToList());
+                    
 
 
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1595,6 +1595,7 @@ namespace FramesToMMSpriteResources
                     if ((TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame)
                     {
                         FrameCoordinateEditorControl.SetSpriteImage(animationSpriteFrame.WriteableBitmaps[selectedIndex]);
+                        FrameCoordinateEditorControl.SetAnimationPreviewFrames(animationSpriteFrame.WriteableBitmaps, animationConfig.frameCongfigs.Select(frame => frame.Offset).ToList());
 
 
 


### PR DESCRIPTION
### Motivation
- Improve frame offset editing by allowing quick keyboard nudges and provide a live animation preview so artists can see the assembled animation while adjusting offsets. 

### Description
- Made the frame editor keyboard-focusable and added a `KeyDown` handler to nudge offsets with `W`/`A`/`S`/`D`, and capture focus on canvas click so keyboard input works immediately (`FrameCoordinateEditor.xaml` / `FrameCoordinateEditor.xaml.cs`).
- Added a floating top-right animation preview panel (`AnimationPreviewImage`) inside the canvas area and crosshair guides to indicate origin (`FrameCoordinateEditor.xaml`).
- Implemented a `DispatcherTimer` running at 60 Hz and `SetAnimationPreviewFrames(...)` API that accepts frame `WriteableBitmap`s and per-frame offsets; frames advance every `PreviewTicksPerFrame = 2` ticks to produce a one-frame delay between sprite frames on a 60fps display (`FrameCoordinateEditor.xaml.cs`).
- Wired the preview from `MainWindow` so the editor receives the animation bitmaps and offsets when a frame is selected (`MainWindow.xaml.cs`).

### Testing
- Attempted to build with `dotnet build FramesToMMSpriteResources.slnx`, but the environment lacks the `dotnet` SDK so compilation could not be executed here (`/bin/bash: line 1: dotnet: command not found`).
- No automated unit tests were run in this environment; changes were committed locally with a descriptive commit message. `git commit` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbb328c688327ab41fbd4e04fb17d)