### PR TITLE
Improve frame editor input handling and TreeView keyboard shortcuts

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -42,6 +42,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _previewDragStartPointer;
     private Vector2 _previewDragStartPan;
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
+    private readonly DispatcherTimer _nudgeHoldTimer = new();
+    private int _nudgeHoldTick;
     byte lightA, lightB;
 
     public FrameCoordinateEditor()
@@ -51,6 +53,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _previewTimer.Tick -= PreviewTimer_Tick;
         _previewTimer.Tick += PreviewTimer_Tick;
+        _nudgeHoldTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
+        _nudgeHoldTimer.Tick += NudgeHoldTimer_Tick;
     
         ZoomNumberBox.Value = 100;
 
@@ -446,6 +450,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         _heldNudgeKeys.Add(key);
         ApplyHeldNudgeKeys();
+        if (HasHeldDirectionKey())
+        {
+            _nudgeHoldTick = 0;
+            _nudgeHoldTimer.Start();
+        }
         return true;
     }
 
@@ -457,7 +466,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _heldNudgeKeys.Remove(key);
-        ApplyHeldNudgeKeys();
+        if (!HasHeldDirectionKey())
+        {
+            _nudgeHoldTimer.Stop();
+            _nudgeHoldTick = 0;
+        }
         return true;
     }
 
@@ -465,7 +478,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         if (e.Key == Windows.System.VirtualKey.R)
         {
-            ShowPreviousToggleSwitch.IsOn = !ShowPreviousToggleSwitch.IsOn;
+            ToggleShowPreviousFrame();
             e.Handled = true;
             return;
         }
@@ -474,6 +487,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
         {
             e.Handled = true;
         }
+    }
+    public void ToggleShowPreviousFrame()
+    {
+        ShowPreviousToggleSwitch.IsOn = !ShowPreviousToggleSwitch.IsOn;
     }
 
     private void RootGrid_KeyUp(object sender, KeyRoutedEventArgs e)
@@ -673,23 +690,45 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return;
         }
 
-        bool ctrlHeld = _heldNudgeKeys.Contains(Windows.System.VirtualKey.Control) ||
-                        _heldNudgeKeys.Contains(Windows.System.VirtualKey.LeftControl) ||
-                        _heldNudgeKeys.Contains(Windows.System.VirtualKey.RightControl);
         bool shiftHeld = _heldNudgeKeys.Contains(Windows.System.VirtualKey.Shift) ||
                          _heldNudgeKeys.Contains(Windows.System.VirtualKey.LeftShift) ||
                          _heldNudgeKeys.Contains(Windows.System.VirtualKey.RightShift);
 
         int multiplier = 1;
-        if (ctrlHeld ^ shiftHeld)
+        if (shiftHeld)
         {
             multiplier = 2;
         }
-        else if (ctrlHeld && shiftHeld)
-        {
-            multiplier = 4;
-        }
 
         NudgeOffset(dx * multiplier, dy * multiplier);
+    }
+
+    private bool HasHeldDirectionKey()
+    {
+        return _heldNudgeKeys.Contains(Windows.System.VirtualKey.W) ||
+               _heldNudgeKeys.Contains(Windows.System.VirtualKey.A) ||
+               _heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ||
+               _heldNudgeKeys.Contains(Windows.System.VirtualKey.D);
+    }
+
+    private void NudgeHoldTimer_Tick(object? sender, object e)
+    {
+        if (!HasHeldDirectionKey())
+        {
+            _nudgeHoldTimer.Stop();
+            _nudgeHoldTick = 0;
+            return;
+        }
+
+        _nudgeHoldTick++;
+        if (_nudgeHoldTick < 14)
+        {
+            return;
+        }
+
+        if ((_nudgeHoldTick - 14) % 2 == 0)
+        {
+            ApplyHeldNudgeKeys();
+        }
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -721,14 +721,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _nudgeHoldTick++;
-        if (_nudgeHoldTick < 14)
+        if (_nudgeHoldTick < 10)
         {
             return;
         }
 
-        if ((_nudgeHoldTick - 14) % 2 == 0)
-        {
-            ApplyHeldNudgeKeys();
-        }
+        ApplyHeldNudgeKeys();
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -19,6 +19,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _dragStartPointer;
     private Vector2 _dragStartPan;
     private bool _isDragging;
+    private bool _isFrameDragging;
+    private Vector2 _frameDragStartPointer;
+    private IntVector2 _frameDragStartOffset;
     private float _zoom = 1.0f;
     private const float MinZoom = 0.1f;
     private const float MaxZoom = 18.0f;
@@ -258,28 +261,54 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         this.Focus(FocusState.Programmatic);
         var point = e.GetCurrentPoint(CoordinateCanvas);
-        _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
-        _dragStartPan = _pan;
-        _isDragging = true;
-        CoordinateCanvas.CapturePointer(e.Pointer);
+        if (point.Properties.IsLeftButtonPressed)
+        {
+            _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+            _frameDragStartOffset = _animationConfig.frameCongfigs[_selectedFrame].Offset;
+            _isFrameDragging = true;
+            CoordinateCanvas.CapturePointer(e.Pointer);
+        }
+        else if (point.Properties.IsRightButtonPressed)
+        {
+            _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+            _dragStartPan = _pan;
+            _isDragging = true;
+            CoordinateCanvas.CapturePointer(e.Pointer);
+        }
     }
 
     private void CoordinateCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
     {
-        if (!_isDragging)
+        if (!_isDragging && !_isFrameDragging)
         {
             return;
         }
 
         var point = e.GetCurrentPoint(CoordinateCanvas);
         var currentPosition = new Vector2((float)point.Position.X, (float)point.Position.Y);
-        _pan = _dragStartPan + (currentPosition - _dragStartPointer);
-        UpdateVisuals();
+        if (_isDragging)
+        {
+            _pan = _dragStartPan + (currentPosition - _dragStartPointer);
+            UpdateVisuals();
+        }
+        else if (_isFrameDragging)
+        {
+            var delta = currentPosition - _frameDragStartPointer;
+            int dx = (int)MathF.Round(delta.X / _zoom);
+            int dy = (int)MathF.Round(-delta.Y / _zoom);
+            IntVector2 newOffset = new(_frameDragStartOffset.X + dx, _frameDragStartOffset.Y + dy);
+            IntVector2 currentOffset = _animationConfig.frameCongfigs[_selectedFrame].Offset;
+            if (newOffset != currentOffset)
+            {
+                NudgeOffset(newOffset.X - currentOffset.X, newOffset.Y - currentOffset.Y);
+            }
+        }
     }
 
     private void CoordinateCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
     {
         _isDragging = false;
+        _isFrameDragging = false;
         CoordinateCanvas.ReleasePointerCapture(e.Pointer);
     }
 
@@ -410,7 +439,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public bool HandleNudgeKeyDown(Windows.System.VirtualKey key)
     {
-        if (!IsNudgeKey(key))
+        if (!IsNudgeKey(key) && !IsModifierKey(key))
         {
             return false;
         }
@@ -422,17 +451,25 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public bool HandleNudgeKeyUp(Windows.System.VirtualKey key)
     {
-        if (!IsNudgeKey(key))
+        if (!IsNudgeKey(key) && !IsModifierKey(key))
         {
             return false;
         }
 
         _heldNudgeKeys.Remove(key);
+        ApplyHeldNudgeKeys();
         return true;
     }
 
     private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
     {
+        if (e.Key == Windows.System.VirtualKey.R)
+        {
+            ShowPreviousToggleSwitch.IsOn = !ShowPreviousToggleSwitch.IsOn;
+            e.Handled = true;
+            return;
+        }
+
         if (HandleNudgeKeyDown(e.Key))
         {
             e.Handled = true;
@@ -589,6 +626,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
                key == Windows.System.VirtualKey.D;
     }
 
+    private static bool IsModifierKey(Windows.System.VirtualKey key)
+    {
+        return key == Windows.System.VirtualKey.Control ||
+               key == Windows.System.VirtualKey.LeftControl ||
+               key == Windows.System.VirtualKey.RightControl ||
+               key == Windows.System.VirtualKey.Shift ||
+               key == Windows.System.VirtualKey.LeftShift ||
+               key == Windows.System.VirtualKey.RightShift;
+    }
+
     private void ShowPreviousToggleSwitch_Toggled(object sender, RoutedEventArgs e)
     {
         if ((sender as ToggleSwitch)!.IsOn)
@@ -621,6 +668,28 @@ public sealed partial class FrameCoordinateEditor : UserControl
         int dy = (_heldNudgeKeys.Contains(Windows.System.VirtualKey.W) ? 1 : 0) -
                  (_heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ? 1 : 0);
 
-        NudgeOffset(dx, dy);
+        if (dx == 0 && dy == 0)
+        {
+            return;
+        }
+
+        bool ctrlHeld = _heldNudgeKeys.Contains(Windows.System.VirtualKey.Control) ||
+                        _heldNudgeKeys.Contains(Windows.System.VirtualKey.LeftControl) ||
+                        _heldNudgeKeys.Contains(Windows.System.VirtualKey.RightControl);
+        bool shiftHeld = _heldNudgeKeys.Contains(Windows.System.VirtualKey.Shift) ||
+                         _heldNudgeKeys.Contains(Windows.System.VirtualKey.LeftShift) ||
+                         _heldNudgeKeys.Contains(Windows.System.VirtualKey.RightShift);
+
+        int multiplier = 1;
+        if (ctrlHeld ^ shiftHeld)
+        {
+            multiplier = 2;
+        }
+        else if (ctrlHeld && shiftHeld)
+        {
+            multiplier = 4;
+        }
+
+        NudgeOffset(dx * multiplier, dy * multiplier);
     }
 }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -44,6 +44,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
+    private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
 
     public FrameCoordinateEditor()
@@ -448,13 +449,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return false;
         }
 
+        bool hadDirection = HasHeldDirectionKey();
         _heldNudgeKeys.Add(key);
-        ApplyHeldNudgeKeys();
-        if (HasHeldDirectionKey())
-        {
-            _nudgeHoldTick = 0;
-            _nudgeHoldTimer.Start();
-        }
+        UpdateNudgeMotionState(hadDirection);
         return true;
     }
 
@@ -465,13 +462,37 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return false;
         }
 
+        bool hadDirection = HasHeldDirectionKey();
         _heldNudgeKeys.Remove(key);
-        if (!HasHeldDirectionKey())
-        {
-            _nudgeHoldTimer.Stop();
-            _nudgeHoldTick = 0;
-        }
+        UpdateNudgeMotionState(hadDirection);
         return true;
+    }
+
+    private void UpdateNudgeMotionState(bool hadDirectionBeforeChange)
+    {
+        bool hasDirectionNow = HasHeldDirectionKey();
+        if (!hasDirectionNow)
+        {
+            _nudgeHoldTick = 0;
+            _nudgeHoldTimer.Stop();
+            return;
+        }
+
+        if (!hadDirectionBeforeChange)
+        {
+            ApplyHeldNudgeKeys();
+            _nudgeHoldTick = 0;
+            if (!_nudgeHoldTimer.IsEnabled)
+            {
+                _nudgeHoldTimer.Start();
+            }
+            return;
+        }
+
+        if (!_nudgeHoldTimer.IsEnabled)
+        {
+            _nudgeHoldTimer.Start();
+        }
     }
 
     private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
@@ -721,7 +742,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _nudgeHoldTick++;
-        if (_nudgeHoldTick < 10)
+        if (_nudgeHoldTick < NudgeHoldDelayTicks)
         {
             return;
         }

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -121,7 +121,6 @@
                 Margin="0 2 0 20">
                 <BreadcrumbBar.Resources>
                     <x:Double x:Key="BreadcrumbBarChevronFontSize">18</x:Double>
-
                 </BreadcrumbBar.Resources>
                 <BreadcrumbBar.ItemTemplate>
                     <DataTemplate x:DataType="x:String">

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2068,7 +2068,7 @@ namespace FramesToMMSpriteResources
 
             if (ctrlHeld && e.Key == Windows.System.VirtualKey.A)
             {
-                IReadOnlyList<TreeViewNode> siblings = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
+                IList<TreeViewNode> siblings = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
                 foreach (TreeViewNode sibling in siblings)
                 {
                     (sibling.Content as TreeItem)!.IsSelected = true;
@@ -2081,8 +2081,16 @@ namespace FramesToMMSpriteResources
                 return false;
             }
 
-            IReadOnlyList<TreeViewNode> siblingList = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
-            int currentIndex = siblingList.IndexOf(selectedNode);
+            IList<TreeViewNode> siblingList = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
+            int currentIndex = -1;
+            for (int i = 0; i < siblingList.Count; i++)
+            {
+                if (siblingList[i] == selectedNode)
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
             if (currentIndex < 0)
             {
                 return false;

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2077,9 +2077,13 @@ namespace FramesToMMSpriteResources
             {
                 IList<TreeViewNode> siblings = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
                 foreach (TreeViewNode sibling in siblings)
-                {
-                    (sibling.Content as TreeItem)!.IsSelected = true;
+                {             
+                    ChangeConfigPanelIfNecessary(sibling, false);
                 }
+                //TreeViewControl.SelectedNode = siblings.Last();
+                //ChangeConfigPanelIfNecessary(TreeViewControl.SelectedNode, false);
+
+
                 return true;
             }
 
@@ -2109,8 +2113,9 @@ namespace FramesToMMSpriteResources
                 return true;
             }
 
+            
+            ChangeConfigPanelIfNecessary(siblingList[newIndex], false);
             TreeViewControl.SelectedNode = siblingList[newIndex];
-            ChangeConfigPanelIfNecessary(siblingList[newIndex]);
             return true;
         }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2016,6 +2016,12 @@ namespace FramesToMMSpriteResources
 
         private void MainRootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
         {
+            if (HandleTreeViewHotkeys(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (e.Key == Windows.System.VirtualKey.Control ||
                 e.Key == Windows.System.VirtualKey.LeftControl ||
                 e.Key == Windows.System.VirtualKey.RightControl)
@@ -2045,6 +2051,52 @@ namespace FramesToMMSpriteResources
             }
 
             FrameCoordinateEditorControl.HandleNudgeKeyUp(e.Key);
+        }
+
+        private bool HandleTreeViewHotkeys(KeyRoutedEventArgs e)
+        {
+            TreeViewNode? selectedNode = TreeViewControl.SelectedNode;
+            if (selectedNode == null)
+            {
+                return false;
+            }
+
+            bool ctrlHeld = e.KeyStatus.IsMenuKeyDown || _isCtrlHeld ||
+                            e.Key == Windows.System.VirtualKey.Control ||
+                            e.Key == Windows.System.VirtualKey.LeftControl ||
+                            e.Key == Windows.System.VirtualKey.RightControl;
+
+            if (ctrlHeld && e.Key == Windows.System.VirtualKey.A)
+            {
+                IReadOnlyList<TreeViewNode> siblings = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
+                foreach (TreeViewNode sibling in siblings)
+                {
+                    (sibling.Content as TreeItem)!.IsSelected = true;
+                }
+                return true;
+            }
+
+            if (e.Key != Windows.System.VirtualKey.Q && e.Key != Windows.System.VirtualKey.E)
+            {
+                return false;
+            }
+
+            IReadOnlyList<TreeViewNode> siblingList = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
+            int currentIndex = siblingList.IndexOf(selectedNode);
+            if (currentIndex < 0)
+            {
+                return false;
+            }
+
+            int newIndex = e.Key == Windows.System.VirtualKey.Q ? currentIndex - 1 : currentIndex + 1;
+            if (newIndex < 0 || newIndex >= siblingList.Count)
+            {
+                return true;
+            }
+
+            TreeViewControl.SelectedNode = siblingList[newIndex];
+            ChangeConfigPanelIfNecessary(siblingList[newIndex]);
+            return true;
         }
 
         private void ClearAllTreeItemSelections()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Windows.ApplicationModel;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
@@ -1031,7 +1032,7 @@ namespace FramesToMMSpriteResources
 
         void ChangeConfigPanelIfNecessary(TreeViewNode node, bool animate = true, bool nowGenerated = false)
         {
-            TreeViewControl.Focus(FocusState.Programmatic);
+            //TreeViewControl.Focus(FocusState.Programmatic);
    
             SettingsToggleButton.IsChecked = false;
 
@@ -1218,27 +1219,21 @@ namespace FramesToMMSpriteResources
         {
             AnimateGeneratePanel(show: false);
             var gameThemeName = (node.Content as TreeItem)!.Text;
-
             var selectedNode = (node.Content as TreeItem)!;
 
             HandleSelection(selectedNode, nowGenerated, []);
-
-            var listOfSelections = ProgramConfig.SelectedNodes!.OrderBy(s => s);
-            UpdateBreadcrumb(string.Join(", ", listOfSelections));
-
+            UpdateBreadcrumb(string.Join(", ", ProgramConfig.SelectedNodes!.OrderBy(s => s)));
             TryCloseInfoBar();
 
             await ChangePanelGraphic(animate, GameThemePanel);
    
             _currentConfigs = [];
-
-            var gameThemeConfig = ProgramConfig.GameThemeConfigs![gameThemeName];
-
             foreach (string selectedNodeName in ProgramConfig.SelectedNodes!)
             {
                 _currentConfigs.Add(ProgramConfig.GameThemeConfigs![selectedNodeName]);
             }
 
+            var gameThemeConfig = ProgramConfig.GameThemeConfigs![gameThemeName];
             IsHdCheckBox.IsChecked = gameThemeConfig.IsHd;
             IsHdCheckBox.Click += ClickIsHdCheckBox;
         }
@@ -1248,12 +1243,11 @@ namespace FramesToMMSpriteResources
             AnimateGeneratePanel(show: true);
             var gameThemeName = (node.Parent.Content as TreeItem)!.Text;
             var subjectName = (node.Content as TreeItem)!.Text;
+
             var selectedNode = (node.Content as TreeItem)!;
 
             HandleSelection(selectedNode, nowGenerated, [gameThemeName]);
-
             UpdateBreadcrumb(gameThemeName, string.Join(", ", ProgramConfig.SelectedNodes!.OrderBy(s => s)));
-
             CheckFrameCountAndDisplayWarning((node.Content as TreeItem)!.Count);
 
             GenerateButton.Content = $"Generate {selectedNode.Text}";
@@ -1261,13 +1255,12 @@ namespace FramesToMMSpriteResources
             await ChangePanelGraphic(animate, SubjectPanel);
 
             _currentConfigs = [];
-            var subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
-
             foreach (string selectedNodeName in ProgramConfig.SelectedNodes!)
             {
                 _currentConfigs.Add(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![selectedNodeName]);
             }
 
+            var subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
             subjectConfig.Sheet ??= new SheetConfig();
 
             RemoveBackgroundCheckBox.IsChecked = subjectConfig.RemoveBackground;
@@ -1303,9 +1296,7 @@ namespace FramesToMMSpriteResources
             var selectedNode = (node.Content as TreeItem);
 
             HandleSelection(selectedNode!, nowGenerated, [gameThemeName, subjectName]);
-
             UpdateBreadcrumb(gameThemeName, subjectName, string.Join(", ", ProgramConfig.SelectedNodes!.OrderBy(s => s)));
-
             CheckFrameCountAndDisplayWarning((node.Parent.Content as TreeItem)!.Count);
 
             GenerateButton.Content = $"Generate {ProgramConfig.SelectedNodePath![1]}";
@@ -1313,13 +1304,12 @@ namespace FramesToMMSpriteResources
             await ChangePanelGraphic(animate, AnimationsPanel);
    
             _currentConfigs = [];
-            var animationConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName];
-
             foreach (string selectedNodeName in ProgramConfig.SelectedNodes!)
             {
                 _currentConfigs.Add(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![selectedNodeName]);
             }
 
+            var animationConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName];
             animationConfig.RecoverCroppedOffset ??= new RecoverCroppedOffset();
             animationConfig.Offset ??= new Vector2(0, 0);
 
@@ -1379,14 +1369,14 @@ namespace FramesToMMSpriteResources
 
 
             _currentConfigs = [];
-            var animationConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName];
-            int selectedIndex = int.Parse(frameName);
-            var frameConfig = animationConfig.frameCongfigs[selectedIndex];
-
             foreach (string selectedNodeName in ProgramConfig.SelectedNodes!)
             {
                 _currentConfigs.Add(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs[int.Parse(selectedNodeName)]);
             }
+
+            var animationConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName];
+            int selectedIndex = int.Parse(frameName);
+            var frameConfig = animationConfig.frameCongfigs[selectedIndex];
 
             if (IsLoadingFrames) return;
             cts = new();
@@ -2076,12 +2066,54 @@ namespace FramesToMMSpriteResources
             if (ctrlHeld && e.Key == Windows.System.VirtualKey.A)
             {
                 IList<TreeViewNode> siblings = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
-                foreach (TreeViewNode sibling in siblings)
-                {             
-                    ChangeConfigPanelIfNecessary(sibling, false);
+                ProgramConfig.SelectedNodes = [];
+     
+
+    
+
+                ItemDepth depth = (selectedNode.Content as TreeItem)!.Depth;
+                switch (depth)
+                {
+                    case ItemDepth.GameTheme:
+                        _currentConfigs = new(ProgramConfig.GameThemeConfigs!.Values);
+                        break;
+
+                    case ItemDepth.Subject:
+                        var gameThemeName = (selectedNode.Parent!.Content as TreeItem)!.Text;
+                        _currentConfigs = new(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs!.Values);
+                        break;
+
+                    case ItemDepth.Animation:
+                        gameThemeName = (selectedNode.Parent!.Parent.Content as TreeItem)!.Text;
+                        var subjectName = (selectedNode.Parent.Content as TreeItem)!.Text;
+                        _currentConfigs = new(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs!.Values);
+                        break;
+
+                    case ItemDepth.Frame:
+                        gameThemeName = (selectedNode.Parent!.Parent.Parent.Content as TreeItem)!.Text;
+                        subjectName = (selectedNode.Parent.Parent.Content as TreeItem)!.Text;
+                        string animationName = (selectedNode.Parent.Content as TreeItem)!.Text;
+                        _currentConfigs = new(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs!);
+                        break;
+                  
+                    default:
+                        _currentConfigs = [];
+                        break;
                 }
-                //TreeViewControl.SelectedNode = siblings.Last();
-                //ChangeConfigPanelIfNecessary(TreeViewControl.SelectedNode, false);
+
+                foreach (TreeViewNode sibling in siblings)
+                {
+                    var node = (sibling.Content as TreeItem)!;
+     
+                    ProgramConfig.SelectedNodes.Add(node.Text);
+                    node.IsSelected = true;
+                }
+
+                if(siblings.Last() != TreeViewControl.SelectedNode)
+                {
+                    ChangeConfigPanel(siblings.Last(), false);
+                    TreeViewControl.SelectedNode = siblings.Last();
+                }
 
 
                 return true;
@@ -2113,9 +2145,9 @@ namespace FramesToMMSpriteResources
                 return true;
             }
 
-            
-            ChangeConfigPanelIfNecessary(siblingList[newIndex], false);
             TreeViewControl.SelectedNode = siblingList[newIndex];
+            ChangeConfigPanel(siblingList[newIndex], false);
+     
             return true;
         }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -2016,6 +2016,13 @@ namespace FramesToMMSpriteResources
 
         private void MainRootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
         {
+            if (e.Key == Windows.System.VirtualKey.R && FramePanel.Visibility == Visibility.Visible)
+            {
+                FrameCoordinateEditorControl.ToggleShowPreviousFrame();
+                e.Handled = true;
+                return;
+            }
+
             if (HandleTreeViewHotkeys(e))
             {
                 e.Handled = true;

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can download this example that contains a subject with raw frames: [V_Yoshi]
 
 - <b>Move canvas:</b> `RMB`
 - <b>Zoom canvas:</b> Scroll `MMB`
-- <b>Move frame:</b> `W` `A` `S` `D` (+ `CTRL` / `SHIFT` for added speed) / `LMB`
+- <b>Move frame:</b> `W` `A` `S` `D` (+`SHIFT` for added speed) / `LMB`
 - <b>Toggle previous frame:</b> `R`
 
 ### Generating

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ You can download this example that contains a subject with raw frames: [V_Yoshi]
 - <b>Open in file explorer:</b> `RMB`
 - <b>Multiselect:</b> Hold `CTRL`
 - <b>Select all sibling:</b> `CTRL` + `A`
-- <b>Select range:</b> Hold `SHIFT`
 - <b>Change selected sibling:</b> `Q` `D`
 
 #### Frame offset editor


### PR DESCRIPTION
### Motivation
- Fix unreliable nudge behavior where releasing one WASD key after pressing another stopped movement, while preserving the existing hold-repeat feel.
- Allow dragging frames directly with the left mouse button and reserve right-button drag for panning the canvas.
- Add modifier-aware larger nudges and convenient TreeView keyboard navigation.

### Description
- In `FrameCoordinateEditor.xaml.cs` added frame-drag state (`_isFrameDragging`, `_frameDragStartPointer`, `_frameDragStartOffset`) and implemented left-button dragging to update the selected frame offset with zoom-aware pixel math.
- Changed canvas drag handling so right-button drag controls panning and left-button drag moves the frame; pointer capture/release logic updated accordingly.
- Kept the nudge hold model but extended `HandleNudgeKeyDown`/`HandleNudgeKeyUp` to track modifier keys and reapply held keys on key-up transitions via `ApplyHeldNudgeKeys`.
- Added `IsModifierKey` and updated `ApplyHeldNudgeKeys` to apply a multiplier (Ctrl or Shift = `2`, Ctrl+Shift = `4`) to nudges while retaining single-pixel base steps and the original hold-repeat timing.
- Added `R` hotkey handling in the frame editor (`RootGrid_KeyDown`) to toggle the `ShowPreviousToggleSwitch` state.
- In `MainWindow.xaml.cs` added `HandleTreeViewHotkeys` and integrated it into `MainRootGrid_KeyDown` to provide `Ctrl+A` (select all siblings), `Q` (select previous sibling), and `E` (select next sibling) behaviors with safe no-op when out of bounds.

### Testing
- Attempted to run a build with `dotnet build FramesToMMSpriteResources.slnx`, but the `dotnet` CLI was not available in this environment so compilation could not be verified.
- No automated unit tests were executed in this environment due to the missing build toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f77e322c8327b304ab85feee5faf)