### PR TITLE
Replace FrameCoordinateEditor layered images with composite pixel renderer

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -23,12 +23,7 @@
                         PointerMoved="CoordinateCanvas_PointerMoved"
                         PointerReleased="CoordinateCanvas_PointerReleased"
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged">
-                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
-                    <Image x:Name="SpriteBeforeImage" Width="48" Height="48" IsHitTestVisible="False" Opacity="0.5"/>
-
-                    <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" Opacity="0.7"/>
-                    <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                    <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
+                    <Image x:Name="EditorCompositeImage" IsHitTestVisible="False" Stretch="None"/>
                 </Canvas>
                 <StackPanel
                     Margin="10"

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -273,11 +273,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 int centerY = (int)Math.Round(worldTop + (bitmap.PixelHeight * _zoom * 0.5));
                 if ((uint)centerX < (uint)w && (uint)centerY < (uint)h)
                 {
-                    int srcX = bitmap.PixelWidth / 2;
-                    int srcY = bitmap.PixelHeight / 2;
-                    int si = (srcY * bitmap.PixelWidth + srcX) * 4;
-                    int di = (centerY * w + centerX) * 4;
-                    BlendPixel(target, di, source[si], source[si + 1], source[si + 2], source[si + 3], opacity);
+                    int si = FindRepresentativeOpaquePixel(source);
+                    if (si >= 0)
+                    {
+                        int di = (centerY * w + centerX) * 4;
+                        BlendPixel(target, di, source[si], source[si + 1], source[si + 2], source[si + 3], opacity);
+                    }
                 }
             }
             return;
@@ -362,13 +363,30 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private static void BlendPixel(Span<byte> target, int di, byte srcB, byte srcG, byte srcR, byte srcA, float opacity)
     {
-        float a = (srcA / 255f) * opacity;
-        if (a <= 0f) return;
-        float invA = 1f - a;
-        target[di] = (byte)((srcB * a) + (target[di] * invA));
-        target[di + 1] = (byte)((srcG * a) + (target[di + 1] * invA));
-        target[di + 2] = (byte)((srcR * a) + (target[di + 2] * invA));
+        int alpha = (int)(srcA * opacity);
+        if (alpha <= 0) return;
+        int inv = 255 - alpha;
+        target[di] = (byte)((srcB * alpha + target[di] * inv) / 255);
+        target[di + 1] = (byte)((srcG * alpha + target[di + 1] * inv) / 255);
+        target[di + 2] = (byte)((srcR * alpha + target[di + 2] * inv) / 255);
         target[di + 3] = 255;
+    }
+
+    private static int FindRepresentativeOpaquePixel(byte[] source)
+    {
+        int best = -1;
+        int bestAlpha = -1;
+        for (int i = 0; i < source.Length; i += 4)
+        {
+            int a = source[i + 3];
+            if (a > bestAlpha)
+            {
+                bestAlpha = a;
+                best = i;
+                if (a == 255) return best;
+            }
+        }
+        return bestAlpha > 0 ? best : -1;
     }
 
     private byte[] GetFramePixels(int frameIndex, WriteableBitmap bitmap, bool grayscale)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
-using System.Runtime.InteropServices;
 using Windows.Globalization;
 using Windows.Globalization.NumberFormatting;
 
@@ -46,6 +45,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
     private const int NudgeHoldDelayTicks = 10;
+    private readonly Dictionary<int, byte[]> _framePixelCache = [];
+    private readonly Dictionary<int, byte[]> _frameGrayPixelCache = [];
     byte lightA, lightB;
 
     public FrameCoordinateEditor()
@@ -126,6 +127,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public void LoadAnimation(IReadOnlyList<WriteableBitmap> frames, AnimationConfig animationConfig)
     {
         _previewFrames = frames;
+        _framePixelCache.Clear();
+        _frameGrayPixelCache.Clear();
         _previewFrameIndex = 0;
         _previewTickCount = 0;
         _animationConfig = animationConfig;
@@ -200,6 +203,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = 255;
             }
         }
+        if (_previewFrames.Count > 0 && _selectedFrame < _previewFrames.Count)
+        {
+            if (ShowPreviousToggleSwitch.IsOn)
+            {
+                int prev = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
+                DrawSpriteToBuffer(prev, _previewFrames[prev], _animationConfig.frameCongfigs[prev].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, true, 0.5f);
+            }
+            DrawSpriteToBuffer(_selectedFrame, _previewFrames[_selectedFrame], _animationConfig.frameCongfigs[_selectedFrame].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, false, 0.7f);
+        }
+
         int axisXi = (int)Math.Round(axisX);
         int axisYi = (int)Math.Round(axisY);
         if (axisXi >= 0 && axisXi < pixelWidth)
@@ -218,51 +231,86 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 pixels[i] = 180; pixels[i + 1] = 180; pixels[i + 2] = 180; pixels[i + 3] = 255;
             }
         }
-
-        if (_previewFrames.Count > 0 && _selectedFrame < _previewFrames.Count)
-        {
-            DrawSpriteToBuffer(_previewFrames[_selectedFrame], _animationConfig.frameCongfigs[_selectedFrame].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, false, 255);
-            if (ShowPreviousToggleSwitch.IsOn)
-            {
-                int prev = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
-                DrawSpriteToBuffer(_previewFrames[prev], _animationConfig.frameCongfigs[prev].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, true, 140);
-            }
-        }
         using Stream stream = _editorCompositeBitmap!.PixelBuffer.AsStream();
         stream.Position = 0;
         stream.Write(_editorPixels!, 0, _editorPixels!.Length);
         _editorCompositeBitmap.Invalidate();
     }
 
-    private void DrawSpriteToBuffer(WriteableBitmap bitmap, IntVector2 offset, double axisX, double axisY, Span<byte> target, int w, int h, bool grayscale, byte alpha)
+    private void DrawSpriteToBuffer(int frameIndex, WriteableBitmap bitmap, IntVector2 offset, double axisX, double axisY, Span<byte> target, int w, int h, bool grayscale, float opacity)
     {
-        byte[] source = new byte[bitmap.PixelWidth * bitmap.PixelHeight * 4];
-        using (Stream sourceStream = bitmap.PixelBuffer.AsStream())
+        byte[] source = GetFramePixels(frameIndex, bitmap, grayscale);
+
+        double worldLeft = axisX + (offset.X * _zoom) - ((bitmap.PixelWidth * _zoom) / 2.0);
+        double worldTop = axisY - (offset.Y * _zoom) - ((bitmap.PixelHeight * _zoom) / 2.0);
+        int minX = Math.Max(0, (int)Math.Floor(worldLeft));
+        int minY = Math.Max(0, (int)Math.Floor(worldTop));
+        int maxX = Math.Min(w, (int)Math.Ceiling(worldLeft + (bitmap.PixelWidth * _zoom)));
+        int maxY = Math.Min(h, (int)Math.Ceiling(worldTop + (bitmap.PixelHeight * _zoom)));
+        if (minX >= maxX || minY >= maxY)
         {
-            sourceStream.Position = 0;
-            _ = sourceStream.Read(source, 0, source.Length);
+            return;
         }
-        int scale = Math.Max(1, (int)Math.Round(_zoom));
-        int left = (int)Math.Round(axisX + (offset.X * _zoom) - ((bitmap.PixelWidth * _zoom) / 2.0));
-        int top = (int)Math.Round(axisY - (offset.Y * _zoom) - ((bitmap.PixelHeight * _zoom) / 2.0));
-        for (int y = 0; y < bitmap.PixelHeight; y++)
-        for (int x = 0; x < bitmap.PixelWidth; x++)
+
+        float invZoom = 1f / _zoom;
+        for (int y = minY; y < maxY; y++)
         {
-            int si = (y * bitmap.PixelWidth + x) * 4;
-            byte b = source[si], g = source[si + 1], r = source[si + 2], a = source[si + 3];
-            if (a == 0) continue;
-            if (grayscale) { byte gv = (byte)((r * 77 + g * 150 + b * 29) >> 8); r = g = b = gv; }
-            int dstX = left + (int)Math.Round(x * _zoom);
-            int dstY = top + (int)Math.Round(y * _zoom);
-            for (int yy = 0; yy < scale; yy++)
-            for (int xx = 0; xx < scale; xx++)
+            int srcY = (int)((y - worldTop) * invZoom);
+            if ((uint)srcY >= bitmap.PixelHeight) continue;
+            for (int x = minX; x < maxX; x++)
             {
-                int tx = dstX + xx, ty = dstY + yy;
-                if ((uint)tx >= w || (uint)ty >= h) continue;
-                int di = (ty * w + tx) * 4;
-                target[di] = b; target[di + 1] = g; target[di + 2] = r; target[di + 3] = Math.Min(alpha, a);
+                int srcX = (int)((x - worldLeft) * invZoom);
+                if ((uint)srcX >= bitmap.PixelWidth) continue;
+                int si = (srcY * bitmap.PixelWidth + srcX) * 4;
+                int di = (y * w + x) * 4;
+                BlendPixel(target, di, source[si], source[si + 1], source[si + 2], source[si + 3], opacity);
             }
         }
+    }
+
+    private static void BlendPixel(Span<byte> target, int di, byte srcB, byte srcG, byte srcR, byte srcA, float opacity)
+    {
+        float a = (srcA / 255f) * opacity;
+        if (a <= 0f) return;
+        float invA = 1f - a;
+        target[di] = (byte)((srcB * a) + (target[di] * invA));
+        target[di + 1] = (byte)((srcG * a) + (target[di + 1] * invA));
+        target[di + 2] = (byte)((srcR * a) + (target[di + 2] * invA));
+        target[di + 3] = 255;
+    }
+
+    private byte[] GetFramePixels(int frameIndex, WriteableBitmap bitmap, bool grayscale)
+    {
+        var cache = grayscale ? _frameGrayPixelCache : _framePixelCache;
+        if (cache.TryGetValue(frameIndex, out byte[]? pixels))
+        {
+            return pixels;
+        }
+
+        byte[] source = new byte[bitmap.PixelWidth * bitmap.PixelHeight * 4];
+        using Stream sourceStream = bitmap.PixelBuffer.AsStream();
+        sourceStream.Position = 0;
+        _ = sourceStream.Read(source, 0, source.Length);
+
+        if (grayscale)
+        {
+            byte[] gray = new byte[source.Length];
+            for (int i = 0; i < source.Length; i += 4)
+            {
+                byte b = source[i];
+                byte g = source[i + 1];
+                byte r = source[i + 2];
+                byte a = source[i + 3];
+                byte l = (byte)((r * 77 + g * 150 + b * 29) >> 8);
+                gray[i] = l; gray[i + 1] = l; gray[i + 2] = l; gray[i + 3] = a;
+            }
+            _frameGrayPixelCache[frameIndex] = gray;
+            _framePixelCache.TryAdd(frameIndex, source);
+            return gray;
+        }
+
+        _framePixelCache[frameIndex] = source;
+        return source;
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -191,26 +191,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
             _editorPixels = new byte[byteCount];
         }
         Span<byte> pixels = _editorPixels!;
-        double tileSize = 4.0 * _zoom;
-        int idx = 0;
-        for (int y = 0; y < pixelHeight; y++)
-        {
-            int tileY = (int)Math.Floor((axisY - y) / tileSize);
-            for (int x = 0; x < pixelWidth; x++)
-            {
-                int tileX = (int)Math.Floor((x - axisX) / tileSize);
-                byte color = ((tileX + tileY) & 1) == 0 ? lightA : lightB;
-                pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = 255;
-            }
-        }
+        FillCheckerboard(pixels, pixelWidth, pixelHeight, axisX, axisY);
         if (_previewFrames.Count > 0 && _selectedFrame < _previewFrames.Count)
         {
-            if (ShowPreviousToggleSwitch.IsOn)
+            bool showPrevious = ShowPreviousToggleSwitch.IsOn;
+            if (showPrevious)
             {
                 int prev = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
                 DrawSpriteToBuffer(prev, _previewFrames[prev], _animationConfig.frameCongfigs[prev].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, true, 0.5f);
             }
-            DrawSpriteToBuffer(_selectedFrame, _previewFrames[_selectedFrame], _animationConfig.frameCongfigs[_selectedFrame].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, false, 0.7f);
+            DrawSpriteToBuffer(_selectedFrame, _previewFrames[_selectedFrame], _animationConfig.frameCongfigs[_selectedFrame].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, false, showPrevious ? 0.7f : 1f);
         }
 
         int axisXi = (int)Math.Round(axisX);
@@ -237,6 +227,34 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _editorCompositeBitmap.Invalidate();
     }
 
+    private void FillCheckerboard(Span<byte> pixels, int width, int height, double axisX, double axisY)
+    {
+        int cellSize = Math.Max(1, (int)Math.Round(4.0 * _zoom));
+        int originX = (int)Math.Floor(axisX);
+        int originY = (int)Math.Floor(axisY);
+        int index = 0;
+        for (int y = 0; y < height; y++)
+        {
+            int tileY = FloorDiv(originY - y, cellSize);
+            for (int x = 0; x < width; x++)
+            {
+                int tileX = FloorDiv(x - originX, cellSize);
+                byte c = ((tileX + tileY) & 1) == 0 ? lightA : lightB;
+                pixels[index++] = c;
+                pixels[index++] = c;
+                pixels[index++] = c;
+                pixels[index++] = 255;
+            }
+        }
+    }
+
+    private static int FloorDiv(int value, int divisor)
+    {
+        int q = value / divisor;
+        int r = value % divisor;
+        return r < 0 ? q - 1 : q;
+    }
+
     private void DrawSpriteToBuffer(int frameIndex, WriteableBitmap bitmap, IntVector2 offset, double axisX, double axisY, Span<byte> target, int w, int h, bool grayscale, float opacity)
     {
         byte[] source = GetFramePixels(frameIndex, bitmap, grayscale);
@@ -253,18 +271,22 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         float invZoom = 1f / _zoom;
+        float srcYOffset = (float)(minY - worldTop);
         for (int y = minY; y < maxY; y++)
         {
-            int srcY = (int)((y - worldTop) * invZoom);
+            int srcY = (int)(srcYOffset * invZoom);
             if ((uint)srcY >= bitmap.PixelHeight) continue;
+            float srcXOffset = (float)(minX - worldLeft);
             for (int x = minX; x < maxX; x++)
             {
-                int srcX = (int)((x - worldLeft) * invZoom);
+                int srcX = (int)(srcXOffset * invZoom);
                 if ((uint)srcX >= bitmap.PixelWidth) continue;
                 int si = (srcY * bitmap.PixelWidth + srcX) * 4;
                 int di = (y * w + x) * 4;
                 BlendPixel(target, di, source[si], source[si + 1], source[si + 2], source[si + 3], opacity);
+                srcXOffset += 1f;
             }
+            srcYOffset += 1f;
         }
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -270,6 +270,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return;
         }
 
+        if (_zoom >= 1f)
+        {
+            DrawSpriteZoomedIn(bitmap, source, worldLeft, worldTop, target, w, h, opacity);
+            return;
+        }
+
         float invZoom = 1f / _zoom;
         float srcYOffset = (float)(minY - worldTop);
         for (int y = minY; y < maxY; y++)
@@ -287,6 +293,46 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 srcXOffset += 1f;
             }
             srcYOffset += 1f;
+        }
+    }
+
+    private void DrawSpriteZoomedIn(WriteableBitmap bitmap, byte[] source, double worldLeft, double worldTop, Span<byte> target, int targetWidth, int targetHeight, float opacity)
+    {
+        for (int srcY = 0; srcY < bitmap.PixelHeight; srcY++)
+        {
+            int y0 = (int)Math.Floor(worldTop + (srcY * _zoom));
+            int y1 = (int)Math.Floor(worldTop + ((srcY + 1) * _zoom));
+            if (y1 <= y0) y1 = y0 + 1;
+            if (y1 <= 0 || y0 >= targetHeight) continue;
+            y0 = Math.Max(0, y0);
+            y1 = Math.Min(targetHeight, y1);
+
+            for (int srcX = 0; srcX < bitmap.PixelWidth; srcX++)
+            {
+                int x0 = (int)Math.Floor(worldLeft + (srcX * _zoom));
+                int x1 = (int)Math.Floor(worldLeft + ((srcX + 1) * _zoom));
+                if (x1 <= x0) x1 = x0 + 1;
+                if (x1 <= 0 || x0 >= targetWidth) continue;
+                x0 = Math.Max(0, x0);
+                x1 = Math.Min(targetWidth, x1);
+
+                int si = (srcY * bitmap.PixelWidth + srcX) * 4;
+                byte b = source[si];
+                byte g = source[si + 1];
+                byte r = source[si + 2];
+                byte a = source[si + 3];
+                if (a == 0) continue;
+
+                for (int y = y0; y < y1; y++)
+                {
+                    int rowBase = (y * targetWidth * 4);
+                    for (int x = x0; x < x1; x++)
+                    {
+                        int di = rowBase + (x * 4);
+                        BlendPixel(target, di, b, g, r, a, opacity);
+                    }
+                }
+            }
         }
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -267,6 +267,19 @@ public sealed partial class FrameCoordinateEditor : UserControl
         int maxY = Math.Min(h, (int)Math.Ceiling(worldTop + (bitmap.PixelHeight * _zoom)));
         if (minX >= maxX || minY >= maxY)
         {
+            if (_zoom < 1f)
+            {
+                int centerX = (int)Math.Round(worldLeft + (bitmap.PixelWidth * _zoom * 0.5));
+                int centerY = (int)Math.Round(worldTop + (bitmap.PixelHeight * _zoom * 0.5));
+                if ((uint)centerX < (uint)w && (uint)centerY < (uint)h)
+                {
+                    int srcX = bitmap.PixelWidth / 2;
+                    int srcY = bitmap.PixelHeight / 2;
+                    int si = (srcY * bitmap.PixelWidth + srcX) * 4;
+                    int di = (centerY * w + centerX) * 4;
+                    BlendPixel(target, di, source[si], source[si + 1], source[si + 2], source[si + 3], opacity);
+                }
+            }
             return;
         }
 
@@ -323,13 +336,24 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 byte a = source[si + 3];
                 if (a == 0) continue;
 
+                bool fullyOpaque = opacity >= 0.999f && a == 255;
                 for (int y = y0; y < y1; y++)
                 {
                     int rowBase = (y * targetWidth * 4);
                     for (int x = x0; x < x1; x++)
                     {
                         int di = rowBase + (x * 4);
-                        BlendPixel(target, di, b, g, r, a, opacity);
+                        if (fullyOpaque)
+                        {
+                            target[di] = b;
+                            target[di + 1] = g;
+                            target[di + 2] = r;
+                            target[di + 3] = 255;
+                        }
+                        else
+                        {
+                            BlendPixel(target, di, b, g, r, a, opacity);
+                        }
                     }
                 }
             }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Runtime.InteropServices;
 using Windows.Globalization;
 using Windows.Globalization.NumberFormatting;
 
@@ -25,8 +26,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private float _zoom = 1.0f;
     private const float MinZoom = 0.1f;
     private const float MaxZoom = 18.0f;
-    private WriteableBitmap? _checkerBitmap;
-    private byte[]? _checkerPixels;
+    private WriteableBitmap? _editorCompositeBitmap;
+    private byte[]? _editorPixels;
     private int _selectedFrame;
     private bool _isUpdatingZoomControls;
     private readonly DispatcherTimer _previewTimer = new();
@@ -69,7 +70,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         SetCheckeredColors();
 
-        _checkerBitmap = null;
+        _editorCompositeBitmap = null;
         UpdateVisuals();
     }
 
@@ -105,7 +106,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void SetSpriteIndex(int index)
     {
-        SpriteImage.Source = _previewFrames[index];
         _selectedFrame = index;
 
         OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
@@ -120,7 +120,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         {
             index = _previewFrames.Count;
         }
-        SpriteBeforeImage.Source = _previewFrames[index - 1];
         UpdateVisuals();
     }
 
@@ -149,8 +148,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void UnloadAnimation()
     {
-        SpriteImage.Source = null;
-        SpriteBeforeImage.Source = null;
+        EditorCompositeImage.Source = null;
         LoadAnimation([], new());
     }
 
@@ -162,99 +160,109 @@ public sealed partial class FrameCoordinateEditor : UserControl
         {
             return;
         }
-
         double centerX = canvasWidth / 2.0;
         double centerY = canvasHeight / 2.0;
         double axisX = centerX + _pan.X;
         double axisY = centerY + _pan.Y;
-
-        UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
-        CheckerboardImage.Width = _checkerBitmap?.PixelWidth ?? canvasWidth;
-        CheckerboardImage.Height = _checkerBitmap?.PixelHeight ?? canvasHeight;
-        Canvas.SetLeft(CheckerboardImage, 0);
-        Canvas.SetTop(CheckerboardImage, 0);
-
-        XAxis.Width = canvasWidth;
-        Canvas.SetLeft(XAxis, 0);
-        Canvas.SetTop(XAxis, axisY - (XAxis.Height / 2.0));
-
-        YAxis.Height = canvasHeight;
-        Canvas.SetLeft(YAxis, axisX - (YAxis.Width / 2.0));
-        Canvas.SetTop(YAxis, 0);
-
-
-        if (SpriteImage.Source == null) return;
-
-        double spriteWidth = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap)!.PixelWidth * _zoom);
-        double spriteHeight = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap)!.PixelHeight * _zoom);
-
-        double spriteCanvasX = axisX + (_animationConfig.frameCongfigs[_selectedFrame].Offset.X * _zoom);
-        double spriteCanvasY = axisY - (_animationConfig.frameCongfigs[_selectedFrame].Offset.Y * _zoom);
-
-        int index = _selectedFrame;
-        if (index == 0)
-        {
-            index = _previewFrames.Count;
-        }
-
-        double spriteBeforeCanvasX = axisX + (_animationConfig.frameCongfigs[index -1].Offset.X * _zoom);
-        double spriteBeforeCanvasY = axisY - (_animationConfig.frameCongfigs[index -1].Offset.Y * _zoom);
-
-        SpriteImage.Width = spriteWidth;
-        SpriteImage.Height = spriteHeight;
-
-        SpriteBeforeImage.Width = spriteWidth;
-        SpriteBeforeImage.Height = spriteHeight;
-
-        Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteWidth / 2.0));
-        Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteHeight / 2.0));
-
-        Canvas.SetLeft(SpriteBeforeImage, spriteBeforeCanvasX - (spriteWidth / 2.0));
-        Canvas.SetTop(SpriteBeforeImage, spriteBeforeCanvasY - (spriteHeight / 2.0));
-
+        RenderEditorComposite((int)Math.Ceiling(canvasWidth), (int)Math.Ceiling(canvasHeight), axisX, axisY);
         UpdateZoomControls();
     }
 
-    private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
+    private void RenderEditorComposite(int pixelWidth, int pixelHeight, double axisX, double axisY)
     {
-        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
-        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
+        pixelWidth = Math.Max(1, pixelWidth);
+        pixelHeight = Math.Max(1, pixelHeight);
         int byteCount = pixelWidth * pixelHeight * 4;
-
-        if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
+        if (_editorCompositeBitmap == null || _editorCompositeBitmap.PixelWidth != pixelWidth || _editorCompositeBitmap.PixelHeight != pixelHeight)
         {
-            _checkerBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
-            _checkerPixels = new byte[byteCount];
-            CheckerboardImage.Source = _checkerBitmap;
+            _editorCompositeBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
+            _editorPixels = new byte[byteCount];
+            EditorCompositeImage.Source = _editorCompositeBitmap;
+            EditorCompositeImage.Width = pixelWidth;
+            EditorCompositeImage.Height = pixelHeight;
+            Canvas.SetLeft(EditorCompositeImage, 0);
+            Canvas.SetTop(EditorCompositeImage, 0);
         }
-        else if (_checkerPixels == null || _checkerPixels.Length != byteCount)
+        else if (_editorPixels == null || _editorPixels.Length != byteCount)
         {
-            _checkerPixels = new byte[byteCount];
+            _editorPixels = new byte[byteCount];
         }
-
+        Span<byte> pixels = _editorPixels!;
         double tileSize = 4.0 * _zoom;
         int idx = 0;
         for (int y = 0; y < pixelHeight; y++)
         {
-  
             int tileY = (int)Math.Floor((axisY - y) / tileSize);
             for (int x = 0; x < pixelWidth; x++)
             {
-      
                 int tileX = (int)Math.Floor((x - axisX) / tileSize);
                 byte color = ((tileX + tileY) & 1) == 0 ? lightA : lightB;
-
-                _checkerPixels![idx++] = color;
-                _checkerPixels[idx++] = color;
-                _checkerPixels[idx++] = color;
-                _checkerPixels[idx++] = 255;
+                pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = color; pixels[idx++] = 255;
+            }
+        }
+        int axisXi = (int)Math.Round(axisX);
+        int axisYi = (int)Math.Round(axisY);
+        if (axisXi >= 0 && axisXi < pixelWidth)
+        {
+            for (int y = 0; y < pixelHeight; y++)
+            {
+                int i = (y * pixelWidth + axisXi) * 4;
+                pixels[i] = 180; pixels[i + 1] = 180; pixels[i + 2] = 180; pixels[i + 3] = 255;
+            }
+        }
+        if (axisYi >= 0 && axisYi < pixelHeight)
+        {
+            for (int x = 0; x < pixelWidth; x++)
+            {
+                int i = (axisYi * pixelWidth + x) * 4;
+                pixels[i] = 180; pixels[i + 1] = 180; pixels[i + 2] = 180; pixels[i + 3] = 255;
             }
         }
 
-        using Stream stream = _checkerBitmap!.PixelBuffer.AsStream();
+        if (_previewFrames.Count > 0 && _selectedFrame < _previewFrames.Count)
+        {
+            DrawSpriteToBuffer(_previewFrames[_selectedFrame], _animationConfig.frameCongfigs[_selectedFrame].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, false, 255);
+            if (ShowPreviousToggleSwitch.IsOn)
+            {
+                int prev = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
+                DrawSpriteToBuffer(_previewFrames[prev], _animationConfig.frameCongfigs[prev].Offset, axisX, axisY, pixels, pixelWidth, pixelHeight, true, 140);
+            }
+        }
+        using Stream stream = _editorCompositeBitmap!.PixelBuffer.AsStream();
         stream.Position = 0;
-        stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
-        _checkerBitmap.Invalidate();
+        stream.Write(_editorPixels!, 0, _editorPixels!.Length);
+        _editorCompositeBitmap.Invalidate();
+    }
+
+    private void DrawSpriteToBuffer(WriteableBitmap bitmap, IntVector2 offset, double axisX, double axisY, Span<byte> target, int w, int h, bool grayscale, byte alpha)
+    {
+        byte[] source = new byte[bitmap.PixelWidth * bitmap.PixelHeight * 4];
+        using (Stream sourceStream = bitmap.PixelBuffer.AsStream())
+        {
+            sourceStream.Position = 0;
+            _ = sourceStream.Read(source, 0, source.Length);
+        }
+        int scale = Math.Max(1, (int)Math.Round(_zoom));
+        int left = (int)Math.Round(axisX + (offset.X * _zoom) - ((bitmap.PixelWidth * _zoom) / 2.0));
+        int top = (int)Math.Round(axisY - (offset.Y * _zoom) - ((bitmap.PixelHeight * _zoom) / 2.0));
+        for (int y = 0; y < bitmap.PixelHeight; y++)
+        for (int x = 0; x < bitmap.PixelWidth; x++)
+        {
+            int si = (y * bitmap.PixelWidth + x) * 4;
+            byte b = source[si], g = source[si + 1], r = source[si + 2], a = source[si + 3];
+            if (a == 0) continue;
+            if (grayscale) { byte gv = (byte)((r * 77 + g * 150 + b * 29) >> 8); r = g = b = gv; }
+            int dstX = left + (int)Math.Round(x * _zoom);
+            int dstY = top + (int)Math.Round(y * _zoom);
+            for (int yy = 0; yy < scale; yy++)
+            for (int xx = 0; xx < scale; xx++)
+            {
+                int tx = dstX + xx, ty = dstY + yy;
+                if ((uint)tx >= w || (uint)ty >= h) continue;
+                int di = (ty * w + tx) * 4;
+                target[di] = b; target[di + 1] = g; target[di + 2] = r; target[di + 3] = Math.Min(alpha, a);
+            }
+        }
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -410,13 +418,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void ALignDownButton_Click(object sender, RoutedEventArgs e)
     {
         OffsetXTextBox.Value = 0;
-        OffsetYTextBox.Value = (SpriteImage.Source as WriteableBitmap)!.PixelHeight / 2;
+        OffsetYTextBox.Value = _previewFrames[_selectedFrame].PixelHeight / 2;
     }
 
     private void ALignTopLeftButton_Click(object sender, RoutedEventArgs e)
     {
-        OffsetXTextBox.Value = ((SpriteImage.Source as WriteableBitmap)!.PixelWidth / 2);
-        OffsetYTextBox.Value = -((SpriteImage.Source as WriteableBitmap)!.PixelHeight / 2);
+        OffsetXTextBox.Value = (_previewFrames[_selectedFrame].PixelWidth / 2);
+        OffsetYTextBox.Value = -(_previewFrames[_selectedFrame].PixelHeight / 2);
     }
 
     private void ALignCenterButton_Click(object sender, RoutedEventArgs e)
@@ -676,17 +684,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void ShowPreviousToggleSwitch_Toggled(object sender, RoutedEventArgs e)
     {
-        if ((sender as ToggleSwitch)!.IsOn)
-        {
-            SpriteBeforeImage.Visibility = Visibility.Visible;
-            SpriteImage.Opacity = 0.7;
-        }
-        else
-        {
-            SpriteBeforeImage.Visibility = Visibility.Collapsed;
-            SpriteImage.Opacity = 1;
-        }
-     
+        UpdateVisuals();
     }
 
     private void FromNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)


### PR DESCRIPTION
### Motivation
- The editor previously relied on stacked `Image` UI elements and scaled the sprite images which produced smoothing artifacts and prevented nearest-neighbor (pixel-perfect) rendering. 
- It must be possible to show the previous frame grayscaled and keep the sprite pixels sharply blocky when zoomed. 
- A single fast composite render pass is preferable for performance and for keeping axes, checkerboard and sprites perfectly aligned.

### Description
- Replaced the layered `CheckerboardImage`/`SpriteBeforeImage`/`SpriteImage` and axis rectangles with a single `Image` named `EditorCompositeImage` in the XAML. 
- Added a software compositor that writes a checkerboard, axes, current sprite, and (optionally) the previous sprite directly into a `WriteableBitmap` pixel buffer (`_editorCompositeBitmap`) to avoid UI scaling artifacts. 
- Implemented nearest-neighbor scaling by expanding source pixels into integer blocks during the composite pass and added an on-demand grayscale conversion for the previous-frame overlay. 
- Updated related logic to use the composite buffer (unload, set index, align helpers, theme change) and kept existing pan/zoom/drag behavior intact while minimizing per-frame allocations by reusing the pixel buffer where possible.

### Testing
- Attempted to build the solution with `dotnet build FramesToMMSpriteResources.slnx`, but the command failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`). No automated builds succeeded in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d63165d88327872c34c27669e056)