### PR TITLE
Replace FrameCoordinateEditor rendering with SkiaSharp SKXamlCanvas (nearest-neighbor)

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -2,7 +2,7 @@
     x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:skia="using:SkiaSharp.Views.Windows"
+    xmlns:skia="using:SkiaSharp.Views.WinUI"
     IsTabStop="True"
     KeyDown="RootGrid_KeyDown"
     KeyUp="RootGrid_KeyUp">

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -2,7 +2,7 @@
     x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:skia="using:SkiaSharp.Views.WinUI"
+    xmlns:skia="using:SkiaSharp.Views.Windows"
     IsTabStop="True"
     KeyDown="RootGrid_KeyDown"
     KeyUp="RootGrid_KeyUp">

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -2,6 +2,7 @@
     x:Class="FramesToMMSpriteResources.FrameCoordinateEditor"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:skia="using:SkiaSharp.Views.Windows"
     IsTabStop="True"
     KeyDown="RootGrid_KeyDown"
     KeyUp="RootGrid_KeyUp">
@@ -14,22 +15,15 @@
 
         <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
             <Grid>
-                <Canvas x:Name="CoordinateCanvas"
+                <skia:SKXamlCanvas x:Name="CoordinateCanvas"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        Background="Transparent"
+                        PaintSurface="CoordinateCanvas_PaintSurface"
                         SizeChanged="CoordinateCanvas_SizeChanged"
                         PointerPressed="CoordinateCanvas_PointerPressed"
                         PointerMoved="CoordinateCanvas_PointerMoved"
                         PointerReleased="CoordinateCanvas_PointerReleased"
-                        PointerWheelChanged="CoordinateCanvas_PointerWheelChanged">
-                    <Image x:Name="CheckerboardImage" IsHitTestVisible="False" Stretch="None"/>
-                    <Image x:Name="SpriteBeforeImage" Width="48" Height="48" IsHitTestVisible="False" Opacity="0.5"/>
-
-                    <Image x:Name="SpriteImage" Width="48" Height="48" IsHitTestVisible="False" Opacity="0.7"/>
-                    <Rectangle x:Name="XAxis" Height="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                    <Rectangle x:Name="YAxis" Width="1.5" Fill="{ThemeResource TextFillColorSecondaryBrush}" Opacity="0.8"/>
-                </Canvas>
+                        PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"/>
                 <StackPanel
                     Margin="10"
                     HorizontalAlignment="Right"
@@ -45,26 +39,15 @@
                     MinHeight="175">
                         
 
-                        <Canvas x:Name="AnimationPreviewCanvas"
+                        <skia:SKXamlCanvas x:Name="AnimationPreviewCanvas"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
-                               Background="Transparent"
+                                PaintSurface="AnimationPreviewCanvas_PaintSurface"
                                 SizeChanged="AnimationPreviewCanvas_SizeChanged"
                                 PointerPressed="AnimationPreviewCanvas_PointerPressed"
                                 PointerMoved="AnimationPreviewCanvas_PointerMoved"
                                 PointerReleased="AnimationPreviewCanvas_PointerReleased"
-                                PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged">
-                            <Image x:Name="AnimationPreviewImage" Stretch="Fill"/>
-                            <Rectangle x:Name="PreviewXAxis"
-                                       Height="1"
-                                       Fill="{ThemeResource TextFillColorSecondaryBrush}"
-                                       Opacity="0.8"/>
-                            <Rectangle x:Name="PreviewYAxis"
-                                       Width="1"
-                                       Fill="{ThemeResource TextFillColorSecondaryBrush}"
-                                       Opacity="0.8"/>
-
-                        </Canvas>
+                                PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged"/>
                  
                 </Border>
                     <Border

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -15,7 +15,7 @@
 
         <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
             <Grid>
-                <skia:SKXamlCanvas x:Name="CoordinateCanvas"
+                <skia:SKSwapChainPanel x:Name="CoordinateCanvas"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         PaintSurface="CoordinateCanvas_PaintSurface"
@@ -39,7 +39,7 @@
                     MinHeight="175">
                         
 
-                        <skia:SKXamlCanvas x:Name="AnimationPreviewCanvas"
+                        <skia:SKSwapChainPanel x:Name="AnimationPreviewCanvas"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 PaintSurface="AnimationPreviewCanvas_PaintSurface"

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -53,6 +53,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
+    private bool _mainCanvasInvalidateQueued;
+    private bool _previewCanvasInvalidateQueued;
 
     public FrameCoordinateEditor()
     {
@@ -177,7 +179,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateVisuals()
     {
-        CoordinateCanvas.Invalidate();
+        RequestMainCanvasInvalidate();
         UpdateZoomControls();
     }
 
@@ -547,7 +549,37 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateAnimationPreviewFrame()
     {
-        AnimationPreviewCanvas.Invalidate();
+        RequestPreviewCanvasInvalidate();
+    }
+
+    private void RequestMainCanvasInvalidate()
+    {
+        if (_mainCanvasInvalidateQueued)
+        {
+            return;
+        }
+
+        _mainCanvasInvalidateQueued = true;
+        _ = DispatcherQueue.TryEnqueue(() =>
+        {
+            _mainCanvasInvalidateQueued = false;
+            CoordinateCanvas.Invalidate();
+        });
+    }
+
+    private void RequestPreviewCanvasInvalidate()
+    {
+        if (_previewCanvasInvalidateQueued)
+        {
+            return;
+        }
+
+        _previewCanvasInvalidateQueued = true;
+        _ = DispatcherQueue.TryEnqueue(() =>
+        {
+            _previewCanvasInvalidateQueued = false;
+            AnimationPreviewCanvas.Invalidate();
+        });
     }
 
     private WriteableBitmap? GetCurrentFrame() => (_previewFrames.Count == 0 || _selectedFrame >= _previewFrames.Count) ? null : _previewFrames[_selectedFrame];

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -48,6 +48,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     byte lightA, lightB;
     private readonly Dictionary<WriteableBitmap, SKBitmap> _bitmapCache = [];
     private readonly SKPaint _spritePaint = new() { IsAntialias = false };
+    private readonly SKPaint _previousFramePaint = new() { IsAntialias = false };
     private readonly SKPaint _checkerboardPaint = new() { IsAntialias = false };
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
@@ -56,6 +57,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public FrameCoordinateEditor()
     {
         InitializeComponent();
+        _previousFramePaint.ColorFilter = SKColorFilter.CreateColorMatrix([
+            0.2126f, 0.7152f, 0.0722f, 0, 0,
+            0.2126f, 0.7152f, 0.0722f, 0, 0,
+            0.2126f, 0.7152f, 0.0722f, 0, 0,
+            0, 0, 0, 1, 0
+        ]);
         SetCheckeredColors();
         _previewTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _previewTimer.Tick -= PreviewTimer_Tick;
@@ -587,7 +594,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f);
+                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f, _previousFramePaint);
                 }
             }
         }
@@ -607,24 +614,27 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void DrawCheckerboard(SKCanvas canvas, int width, int height, float axisX, float axisY, float zoom)
     {
-        _checkerboardShader ??= _checkerboardUnitBitmap.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat);
+        _checkerboardShader?.Dispose();
         float tileSize = Math.Max(1f, 4f * zoom);
-        SKMatrix scaleMatrix = SKMatrix.CreateScale(tileSize, tileSize);
-        SKMatrix translationMatrix = SKMatrix.CreateTranslation(axisX, axisY);
-        SKMatrix shaderMatrix = SKMatrix.Concat(scaleMatrix, translationMatrix);
-        _checkerboardPaint.Shader = _checkerboardShader!.WithLocalMatrix(shaderMatrix);
+        SKMatrix shaderMatrix = SKMatrix.CreateScaleTranslation(tileSize, tileSize, axisX, axisY);
+        _checkerboardShader = _checkerboardUnitBitmap.ToShader(
+            SKShaderTileMode.Repeat,
+            SKShaderTileMode.Repeat,
+            new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None),
+            shaderMatrix);
+        _checkerboardPaint.Shader = _checkerboardShader;
         canvas.DrawRect(new SKRect(0f, 0f, width, height), _checkerboardPaint);
     }
 
-    private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, float alpha)
+    private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, float alpha, SKPaint? overridePaint = null)
     {
         float width = Math.Max(1f, bitmap.Width * zoom);
         float height = Math.Max(1f, bitmap.Height * zoom);
         float x = axisX + (offset.X * zoom) - (width / 2f);
         float y = axisY - (offset.Y * zoom) - (height / 2f);
-
-        _spritePaint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
-        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), _spritePaint);
+        SKPaint paint = overridePaint ?? _spritePaint;
+        paint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
+        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), paint);
     }
 
     private static bool IsNudgeKey(Windows.System.VirtualKey key)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using SkiaSharp;
-using SkiaSharp.Views.Windows;
+using SkiaSharp.Views.WinUI;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -47,7 +47,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
     private readonly Dictionary<WriteableBitmap, SKBitmap> _bitmapCache = [];
-    private readonly SKPaint _pixelPaint = new() { FilterQuality = SKFilterQuality.None, IsAntialias = false };
+    private readonly SKSamplingOptions _nearestSampling = new(SKFilterMode.Nearest, SKMipmapMode.None);
+    private readonly SKPaint _spritePaint = new() { IsAntialias = false };
+    private readonly SKPaint _checkerboardPaint = new() { IsAntialias = false };
+    private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
+    private SKShader? _checkerboardShader;
+    private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
 
     public FrameCoordinateEditor()
     {
@@ -70,7 +75,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     void ThemeChanged(FrameworkElement fe, object o)
     {
         SetCheckeredColors();
-
+        RebuildCheckerboardShader();
         UpdateVisuals();
     }
 
@@ -88,6 +93,18 @@ public sealed partial class FrameCoordinateEditor : UserControl
             lightA = 30;
             lightB = 60;
         }
+
+        RebuildCheckerboardShader();
+    }
+
+    private void RebuildCheckerboardShader()
+    {
+        _checkerboardUnitBitmap.SetPixel(0, 0, new SKColor(lightA, lightA, lightA, 255));
+        _checkerboardUnitBitmap.SetPixel(1, 1, new SKColor(lightA, lightA, lightA, 255));
+        _checkerboardUnitBitmap.SetPixel(1, 0, new SKColor(lightB, lightB, lightB, 255));
+        _checkerboardUnitBitmap.SetPixel(0, 1, new SKColor(lightB, lightB, lightB, 255));
+        _checkerboardShader?.Dispose();
+        _checkerboardShader = _checkerboardUnitBitmap.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat);
     }
 
     public event Action<IntVector2>? SpritePositionChanged;
@@ -540,24 +557,80 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void DrawCanvas(SKCanvas canvas, int width, int height, bool main)
     {
         canvas.Clear();
+
         float zoom = main ? _zoom : _previewZoom;
         var pan = main ? _pan : _previewPan;
         float axisX = width / 2f + pan.X;
         float axisY = height / 2f + pan.Y;
-        float tile = Math.Max(1f, 4f * zoom);
-        using var p = new SKPaint { IsAntialias = false };
-        for(float y=0;y<height;y+=tile)
-        for(float x=0;x<width;x+=tile){
-            int tx=(int)MathF.Floor((x-axisX)/tile); int ty=(int)MathF.Floor((axisY-y)/tile); byte c=((tx+ty)&1)==0?lightA:lightB; p.Color=new SKColor(c,c,c,255); canvas.DrawRect(x,y,tile,tile,p);}
-        using var axisPaint = new SKPaint{Color=new SKColor(140,140,140,200),StrokeWidth=main?1.5f:1f,IsAntialias=false};
-        canvas.DrawLine(0,axisY,width,axisY,axisPaint); canvas.DrawLine(axisX,0,axisX,height,axisPaint);
-        if(_previewFrames.Count==0) return;
-        if(main){
-            var cur=GetSkBitmap(GetCurrentFrame()); if(cur!=null) DrawFrame(canvas,cur,_animationConfig.frameCongfigs[_selectedFrame].Offset,zoom,axisX,axisY,ShowPreviousToggleSwitch.IsOn?0.7f:1f);
-            if(ShowPreviousToggleSwitch.IsOn){ int i=_selectedFrame==0?_previewFrames.Count-1:_selectedFrame-1; var prev=GetSkBitmap(_previewFrames[i]); if(prev!=null) DrawFrame(canvas,prev,_animationConfig.frameCongfigs[i].Offset,zoom,axisX,axisY,0.5f);}
-        } else { int fi=Math.Clamp(_previewFrameIndex+GetFromValue(),GetFromValue(),GetToValue()); var b=GetSkBitmap(_previewFrames[fi]); if(b!=null){ var off=fi<_animationConfig.frameCongfigs.Count?_animationConfig.frameCongfigs[fi].Offset:new IntVector2(); DrawFrame(canvas,b,off,zoom,axisX,axisY,1f);} }
+
+        DrawCheckerboard(canvas, width, height, axisX, axisY, zoom);
+
+        _axisPaint.StrokeWidth = main ? 1.5f : 1f;
+        canvas.DrawLine(0f, axisY, width, axisY, _axisPaint);
+        canvas.DrawLine(axisX, 0f, axisX, height, _axisPaint);
+
+        if (_previewFrames.Count == 0)
+        {
+            return;
+        }
+
+        if (main)
+        {
+            SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
+            if (currentFrame != null)
+            {
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
+            }
+
+            if (ShowPreviousToggleSwitch.IsOn)
+            {
+                int previousFrameIndex = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
+                SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
+                if (previousFrame != null)
+                {
+                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f);
+                }
+            }
+        }
+        else
+        {
+            int previewFrameIndex = Math.Clamp(_previewFrameIndex + GetFromValue(), GetFromValue(), GetToValue());
+            SKBitmap? previewFrame = GetSkBitmap(_previewFrames[previewFrameIndex]);
+            if (previewFrame != null)
+            {
+                IntVector2 previewOffset = previewFrameIndex < _animationConfig.frameCongfigs.Count
+                    ? _animationConfig.frameCongfigs[previewFrameIndex].Offset
+                    : new IntVector2();
+                DrawFrame(canvas, previewFrame, previewOffset, zoom, axisX, axisY, 1f);
+            }
+        }
     }
-    private void DrawFrame(SKCanvas c, SKBitmap b, IntVector2 off, float z, float ax, float ay, float alpha){ var w=Math.Max(1,b.Width*z); var h=Math.Max(1,b.Height*z); var x=ax+off.X*z-w/2f; var y=ay-off.Y*z-h/2f; _pixelPaint.Color=new SKColor(255,255,255,(byte)(alpha*255)); c.DrawBitmap(b,new SKRect(x,y,x+w,y+h),_pixelPaint);}
+
+    private void DrawCheckerboard(SKCanvas canvas, int width, int height, float axisX, float axisY, float zoom)
+    {
+        _checkerboardShader ??= _checkerboardUnitBitmap.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat);
+        float tileSize = Math.Max(1f, 4f * zoom);
+        float patternSpan = tileSize * 2f;
+        float phaseX = (axisX % patternSpan + patternSpan) % patternSpan;
+        float phaseY = (axisY % patternSpan + patternSpan) % patternSpan;
+
+        SKMatrix scaleMatrix = SKMatrix.CreateScale(tileSize, tileSize);
+        SKMatrix translationMatrix = SKMatrix.CreateTranslation(phaseX, phaseY);
+        SKMatrix shaderMatrix = SKMatrix.Concat(scaleMatrix, translationMatrix);
+        _checkerboardPaint.Shader = _checkerboardShader!.WithLocalMatrix(shaderMatrix);
+        canvas.DrawRect(new SKRect(0f, 0f, width, height), _checkerboardPaint);
+    }
+
+    private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, float alpha)
+    {
+        float width = Math.Max(1f, bitmap.Width * zoom);
+        float height = Math.Max(1f, bitmap.Height * zoom);
+        float x = axisX + (offset.X * zoom) - (width / 2f);
+        float y = axisY - (offset.Y * zoom) - (height / 2f);
+
+        _spritePaint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
+        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), _nearestSampling, _spritePaint);
+    }
 
     private static bool IsNudgeKey(Windows.System.VirtualKey key)
     {

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using SkiaSharp;
-using SkiaSharp.Views.WinUI;
+using SkiaSharp.Views.Windows;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -47,7 +47,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
     private readonly Dictionary<WriteableBitmap, SKBitmap> _bitmapCache = [];
-    private readonly SKSamplingOptions _nearestSampling = new(SKFilterMode.Nearest, SKMipmapMode.None);
     private readonly SKPaint _spritePaint = new() { IsAntialias = false };
     private readonly SKPaint _checkerboardPaint = new() { IsAntialias = false };
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
@@ -610,12 +609,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         _checkerboardShader ??= _checkerboardUnitBitmap.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat);
         float tileSize = Math.Max(1f, 4f * zoom);
-        float patternSpan = tileSize * 2f;
-        float phaseX = (axisX % patternSpan + patternSpan) % patternSpan;
-        float phaseY = (axisY % patternSpan + patternSpan) % patternSpan;
-
         SKMatrix scaleMatrix = SKMatrix.CreateScale(tileSize, tileSize);
-        SKMatrix translationMatrix = SKMatrix.CreateTranslation(phaseX, phaseY);
+        SKMatrix translationMatrix = SKMatrix.CreateTranslation(axisX, axisY);
         SKMatrix shaderMatrix = SKMatrix.Concat(scaleMatrix, translationMatrix);
         _checkerboardPaint.Shader = _checkerboardShader!.WithLocalMatrix(shaderMatrix);
         canvas.DrawRect(new SKRect(0f, 0f, width, height), _checkerboardPaint);
@@ -629,7 +624,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         float y = axisY - (offset.Y * zoom) - (height / 2f);
 
         _spritePaint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
-        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), _nearestSampling, _spritePaint);
+        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), _spritePaint);
     }
 
     private static bool IsNudgeKey(Windows.System.VirtualKey key)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -131,11 +131,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         _selectedFrame = index;
 
-        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
-        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
         OffsetYTextBox.Value = _animationConfig.frameCongfigs[index].Offset.Y;
+        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
+
+        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
 
         UpdateVisuals();
@@ -596,22 +597,20 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         if (main)
         {
-            bool isInteracting = _isDragging || _isFrameDragging;
-            bool showPrevious = ShowPreviousToggleSwitch.IsOn && !isInteracting;
-            if (showPrevious)
+            if (ShowPreviousToggleSwitch.IsOn)
             {
                 int previousFrameIndex = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
                 SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
+                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
                 }
             }
 
             SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, showPrevious ? 0.7f : 1f);
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
             }
         }
         else

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,6 +3,8 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
+using SkiaSharp;
+using SkiaSharp.Views.Windows;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,8 +27,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private float _zoom = 1.0f;
     private const float MinZoom = 0.1f;
     private const float MaxZoom = 18.0f;
-    private WriteableBitmap? _checkerBitmap;
-    private byte[]? _checkerPixels;
     private int _selectedFrame;
     private bool _isUpdatingZoomControls;
     private readonly DispatcherTimer _previewTimer = new();
@@ -46,6 +46,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private int _nudgeHoldTick;
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
+    private readonly Dictionary<WriteableBitmap, SKBitmap> _bitmapCache = [];
+    private readonly SKPaint _pixelPaint = new() { FilterQuality = SKFilterQuality.None, IsAntialias = false };
 
     public FrameCoordinateEditor()
     {
@@ -69,7 +71,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         SetCheckeredColors();
 
-        _checkerBitmap = null;
         UpdateVisuals();
     }
 
@@ -105,7 +106,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void SetSpriteIndex(int index)
     {
-        SpriteImage.Source = _previewFrames[index];
         _selectedFrame = index;
 
         OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
@@ -116,11 +116,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
 
-        if (index == 0)
-        {
-            index = _previewFrames.Count;
-        }
-        SpriteBeforeImage.Source = _previewFrames[index - 1];
         UpdateVisuals();
     }
 
@@ -149,112 +144,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void UnloadAnimation()
     {
-        SpriteImage.Source = null;
-        SpriteBeforeImage.Source = null;
         LoadAnimation([], new());
     }
 
     private void UpdateVisuals()
     {
-        double canvasWidth = CoordinateCanvas.ActualWidth;
-        double canvasHeight = CoordinateCanvas.ActualHeight;
-        if (canvasWidth <= 0 || canvasHeight <= 0)
-        {
-            return;
-        }
-
-        double centerX = canvasWidth / 2.0;
-        double centerY = canvasHeight / 2.0;
-        double axisX = centerX + _pan.X;
-        double axisY = centerY + _pan.Y;
-
-        UpdateCheckerboard(canvasWidth, canvasHeight, axisX, axisY);
-        CheckerboardImage.Width = _checkerBitmap?.PixelWidth ?? canvasWidth;
-        CheckerboardImage.Height = _checkerBitmap?.PixelHeight ?? canvasHeight;
-        Canvas.SetLeft(CheckerboardImage, 0);
-        Canvas.SetTop(CheckerboardImage, 0);
-
-        XAxis.Width = canvasWidth;
-        Canvas.SetLeft(XAxis, 0);
-        Canvas.SetTop(XAxis, axisY - (XAxis.Height / 2.0));
-
-        YAxis.Height = canvasHeight;
-        Canvas.SetLeft(YAxis, axisX - (YAxis.Width / 2.0));
-        Canvas.SetTop(YAxis, 0);
-
-
-        if (SpriteImage.Source == null) return;
-
-        double spriteWidth = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap)!.PixelWidth * _zoom);
-        double spriteHeight = Math.Max(1.0, (SpriteImage.Source as WriteableBitmap)!.PixelHeight * _zoom);
-
-        double spriteCanvasX = axisX + (_animationConfig.frameCongfigs[_selectedFrame].Offset.X * _zoom);
-        double spriteCanvasY = axisY - (_animationConfig.frameCongfigs[_selectedFrame].Offset.Y * _zoom);
-
-        int index = _selectedFrame;
-        if (index == 0)
-        {
-            index = _previewFrames.Count;
-        }
-
-        double spriteBeforeCanvasX = axisX + (_animationConfig.frameCongfigs[index -1].Offset.X * _zoom);
-        double spriteBeforeCanvasY = axisY - (_animationConfig.frameCongfigs[index -1].Offset.Y * _zoom);
-
-        SpriteImage.Width = spriteWidth;
-        SpriteImage.Height = spriteHeight;
-
-        SpriteBeforeImage.Width = spriteWidth;
-        SpriteBeforeImage.Height = spriteHeight;
-
-        Canvas.SetLeft(SpriteImage, spriteCanvasX - (spriteWidth / 2.0));
-        Canvas.SetTop(SpriteImage, spriteCanvasY - (spriteHeight / 2.0));
-
-        Canvas.SetLeft(SpriteBeforeImage, spriteBeforeCanvasX - (spriteWidth / 2.0));
-        Canvas.SetTop(SpriteBeforeImage, spriteBeforeCanvasY - (spriteHeight / 2.0));
-
+        CoordinateCanvas.Invalidate();
         UpdateZoomControls();
-    }
-
-    private void UpdateCheckerboard(double canvasWidth, double canvasHeight, double axisX, double axisY)
-    {
-        int pixelWidth = Math.Max(1, (int)Math.Ceiling(canvasWidth));
-        int pixelHeight = Math.Max(1, (int)Math.Ceiling(canvasHeight));
-        int byteCount = pixelWidth * pixelHeight * 4;
-
-        if (_checkerBitmap == null || _checkerBitmap.PixelWidth != pixelWidth || _checkerBitmap.PixelHeight != pixelHeight)
-        {
-            _checkerBitmap = new WriteableBitmap(pixelWidth, pixelHeight);
-            _checkerPixels = new byte[byteCount];
-            CheckerboardImage.Source = _checkerBitmap;
-        }
-        else if (_checkerPixels == null || _checkerPixels.Length != byteCount)
-        {
-            _checkerPixels = new byte[byteCount];
-        }
-
-        double tileSize = 4.0 * _zoom;
-        int idx = 0;
-        for (int y = 0; y < pixelHeight; y++)
-        {
-  
-            int tileY = (int)Math.Floor((axisY - y) / tileSize);
-            for (int x = 0; x < pixelWidth; x++)
-            {
-      
-                int tileX = (int)Math.Floor((x - axisX) / tileSize);
-                byte color = ((tileX + tileY) & 1) == 0 ? lightA : lightB;
-
-                _checkerPixels![idx++] = color;
-                _checkerPixels[idx++] = color;
-                _checkerPixels[idx++] = color;
-                _checkerPixels[idx++] = 255;
-            }
-        }
-
-        using Stream stream = _checkerBitmap!.PixelBuffer.AsStream();
-        stream.Position = 0;
-        stream.Write(_checkerPixels!, 0, _checkerPixels!.Length);
-        _checkerBitmap.Invalidate();
     }
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -410,13 +306,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void ALignDownButton_Click(object sender, RoutedEventArgs e)
     {
         OffsetXTextBox.Value = 0;
-        OffsetYTextBox.Value = (SpriteImage.Source as WriteableBitmap)!.PixelHeight / 2;
+        OffsetYTextBox.Value = GetCurrentFrame()?.PixelHeight / 2 ?? 0;
     }
 
     private void ALignTopLeftButton_Click(object sender, RoutedEventArgs e)
     {
-        OffsetXTextBox.Value = ((SpriteImage.Source as WriteableBitmap)!.PixelWidth / 2);
-        OffsetYTextBox.Value = -((SpriteImage.Source as WriteableBitmap)!.PixelHeight / 2);
+        OffsetXTextBox.Value = (GetCurrentFrame()?.PixelWidth / 2 ?? 0);
+        OffsetYTextBox.Value = -(GetCurrentFrame()?.PixelHeight / 2 ?? 0);
     }
 
     private void ALignCenterButton_Click(object sender, RoutedEventArgs e)
@@ -613,48 +509,55 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateAnimationPreviewFrame()
     {
-        if (_previewFrames.Count == 0)
-        {
-            AnimationPreviewImage.Source = null;
-            return;
-        }
-
-        int frameIndex = Math.Clamp(_previewFrameIndex + GetFromValue(), GetFromValue(), GetToValue());
-        WriteableBitmap frame = _previewFrames[frameIndex];
-        IntVector2 offset = frameIndex < _animationConfig.frameCongfigs.Count ? _animationConfig.frameCongfigs[frameIndex].Offset : new IntVector2(0, 0);
-
-        double canvasWidth = AnimationPreviewCanvas.ActualWidth;
-        double canvasHeight = AnimationPreviewCanvas.ActualHeight;
-        if (canvasWidth <= 0 || canvasHeight <= 0)
-        {
-            return;
-        }
-
-        double centerX = canvasWidth / 2.0;
-        double centerY = canvasHeight / 2.0;
-        double axisX = centerX + _previewPan.X;
-        double axisY = centerY + _previewPan.Y;
-
-        PreviewXAxis.Width = canvasWidth;
-        Canvas.SetLeft(PreviewXAxis, 0);
-        Canvas.SetTop(PreviewXAxis, axisY - (PreviewXAxis.Height / 2.0));
-
-        PreviewYAxis.Height = canvasHeight;
-        Canvas.SetLeft(PreviewYAxis, axisX - (PreviewYAxis.Width / 2.0));
-        Canvas.SetTop(PreviewYAxis, 0);
-
-        double spriteWidth = Math.Max(1.0, frame.PixelWidth * _previewZoom);
-        double spriteHeight = Math.Max(1.0, frame.PixelHeight * _previewZoom);
-        double spriteCanvasX = axisX + (offset.X * _previewZoom);
-        double spriteCanvasY = axisY - (offset.Y * _previewZoom);
-
-        AnimationPreviewImage.Source = frame;
-        AnimationPreviewImage.Width = spriteWidth;
-        AnimationPreviewImage.Height = spriteHeight;
-        AnimationPreviewImage.RenderTransform = null;
-        Canvas.SetLeft(AnimationPreviewImage, spriteCanvasX - (spriteWidth / 2.0));
-        Canvas.SetTop(AnimationPreviewImage, spriteCanvasY - (spriteHeight / 2.0));
+        AnimationPreviewCanvas.Invalidate();
     }
+
+    private WriteableBitmap? GetCurrentFrame() => (_previewFrames.Count == 0 || _selectedFrame >= _previewFrames.Count) ? null : _previewFrames[_selectedFrame];
+
+    private SKBitmap? GetSkBitmap(WriteableBitmap? wb)
+    {
+        if (wb == null) return null;
+        if (_bitmapCache.TryGetValue(wb, out var cached)) return cached;
+        var bmp = new SKBitmap(wb.PixelWidth, wb.PixelHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var stream = wb.PixelBuffer.AsStream();
+        var pixels = bmp.GetPixelSpan();
+        stream.Position = 0;
+        stream.Read(System.Runtime.InteropServices.MemoryMarshal.AsBytes(pixels));
+        _bitmapCache[wb] = bmp;
+        return bmp;
+    }
+
+    private void CoordinateCanvas_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        DrawCanvas(e.Surface.Canvas, e.Info.Width, e.Info.Height, true);
+    }
+
+    private void AnimationPreviewCanvas_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        DrawCanvas(e.Surface.Canvas, e.Info.Width, e.Info.Height, false);
+    }
+
+    private void DrawCanvas(SKCanvas canvas, int width, int height, bool main)
+    {
+        canvas.Clear();
+        float zoom = main ? _zoom : _previewZoom;
+        var pan = main ? _pan : _previewPan;
+        float axisX = width / 2f + pan.X;
+        float axisY = height / 2f + pan.Y;
+        float tile = Math.Max(1f, 4f * zoom);
+        using var p = new SKPaint { IsAntialias = false };
+        for(float y=0;y<height;y+=tile)
+        for(float x=0;x<width;x+=tile){
+            int tx=(int)MathF.Floor((x-axisX)/tile); int ty=(int)MathF.Floor((axisY-y)/tile); byte c=((tx+ty)&1)==0?lightA:lightB; p.Color=new SKColor(c,c,c,255); canvas.DrawRect(x,y,tile,tile,p);}
+        using var axisPaint = new SKPaint{Color=new SKColor(140,140,140,200),StrokeWidth=main?1.5f:1f,IsAntialias=false};
+        canvas.DrawLine(0,axisY,width,axisY,axisPaint); canvas.DrawLine(axisX,0,axisX,height,axisPaint);
+        if(_previewFrames.Count==0) return;
+        if(main){
+            var cur=GetSkBitmap(GetCurrentFrame()); if(cur!=null) DrawFrame(canvas,cur,_animationConfig.frameCongfigs[_selectedFrame].Offset,zoom,axisX,axisY,ShowPreviousToggleSwitch.IsOn?0.7f:1f);
+            if(ShowPreviousToggleSwitch.IsOn){ int i=_selectedFrame==0?_previewFrames.Count-1:_selectedFrame-1; var prev=GetSkBitmap(_previewFrames[i]); if(prev!=null) DrawFrame(canvas,prev,_animationConfig.frameCongfigs[i].Offset,zoom,axisX,axisY,0.5f);}
+        } else { int fi=Math.Clamp(_previewFrameIndex+GetFromValue(),GetFromValue(),GetToValue()); var b=GetSkBitmap(_previewFrames[fi]); if(b!=null){ var off=fi<_animationConfig.frameCongfigs.Count?_animationConfig.frameCongfigs[fi].Offset:new IntVector2(); DrawFrame(canvas,b,off,zoom,axisX,axisY,1f);} }
+    }
+    private void DrawFrame(SKCanvas c, SKBitmap b, IntVector2 off, float z, float ax, float ay, float alpha){ var w=Math.Max(1,b.Width*z); var h=Math.Max(1,b.Height*z); var x=ax+off.X*z-w/2f; var y=ay-off.Y*z-h/2f; _pixelPaint.Color=new SKColor(255,255,255,(byte)(alpha*255)); c.DrawBitmap(b,new SKRect(x,y,x+w,y+h),_pixelPaint);}
 
     private static bool IsNudgeKey(Windows.System.VirtualKey key)
     {
@@ -676,17 +579,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void ShowPreviousToggleSwitch_Toggled(object sender, RoutedEventArgs e)
     {
-        if ((sender as ToggleSwitch)!.IsOn)
-        {
-            SpriteBeforeImage.Visibility = Visibility.Visible;
-            SpriteImage.Opacity = 0.7;
-        }
-        else
-        {
-            SpriteBeforeImage.Visibility = Visibility.Collapsed;
-            SpriteImage.Opacity = 1;
-        }
-     
+        UpdateVisuals();
     }
 
     private void FromNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -53,8 +53,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
-    private bool _mainCanvasInvalidateQueued;
-    private bool _previewCanvasInvalidateQueued;
 
     public FrameCoordinateEditor()
     {
@@ -179,7 +177,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateVisuals()
     {
-        RequestMainCanvasInvalidate();
+        CoordinateCanvas.Invalidate();
         UpdateZoomControls();
     }
 
@@ -549,37 +547,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateAnimationPreviewFrame()
     {
-        RequestPreviewCanvasInvalidate();
-    }
-
-    private void RequestMainCanvasInvalidate()
-    {
-        if (_mainCanvasInvalidateQueued)
-        {
-            return;
-        }
-
-        _mainCanvasInvalidateQueued = true;
-        _ = DispatcherQueue.TryEnqueue(() =>
-        {
-            _mainCanvasInvalidateQueued = false;
-            CoordinateCanvas.Invalidate();
-        });
-    }
-
-    private void RequestPreviewCanvasInvalidate()
-    {
-        if (_previewCanvasInvalidateQueued)
-        {
-            return;
-        }
-
-        _previewCanvasInvalidateQueued = true;
-        _ = DispatcherQueue.TryEnqueue(() =>
-        {
-            _previewCanvasInvalidateQueued = false;
-            AnimationPreviewCanvas.Invalidate();
-        });
+        AnimationPreviewCanvas.Invalidate();
     }
 
     private WriteableBitmap? GetCurrentFrame() => (_previewFrames.Count == 0 || _selectedFrame >= _previewFrames.Count) ? null : _previewFrames[_selectedFrame];

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -145,6 +145,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public void LoadAnimation(IReadOnlyList<WriteableBitmap> frames, AnimationConfig animationConfig)
     {
         _previewFrames = frames;
+        _bitmapCache.Clear();
+        foreach (WriteableBitmap frame in frames)
+        {
+            _ = GetSkBitmap(frame);
+        }
         _previewFrameIndex = 0;
         _previewTickCount = 0;
         _animationConfig = animationConfig;
@@ -598,14 +603,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f, _previousFramePaint);
+                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
                 }
             }
 
             SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
             }
         }
         else
@@ -617,7 +622,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 IntVector2 previewOffset = previewFrameIndex < _animationConfig.frameCongfigs.Count
                     ? _animationConfig.frameCongfigs[previewFrameIndex].Offset
                     : new IntVector2();
-                DrawFrame(canvas, previewFrame, previewOffset, zoom, axisX, axisY, 1f);
+                DrawFrame(canvas, previewFrame, previewOffset, zoom, axisX, axisY, width, height, 1f);
             }
         }
     }
@@ -635,15 +640,31 @@ public sealed partial class FrameCoordinateEditor : UserControl
         canvas.Restore();
     }
 
-    private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, float alpha, SKPaint? overridePaint = null)
+    private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, int viewportWidth, int viewportHeight, float alpha, SKPaint? overridePaint = null)
     {
         float width = Math.Max(1f, bitmap.Width * zoom);
         float height = Math.Max(1f, bitmap.Height * zoom);
         float x = axisX + (offset.X * zoom) - (width / 2f);
         float y = axisY - (offset.Y * zoom) - (height / 2f);
+        SKRect destRect = new(x, y, x + width, y + height);
+        SKRect viewportRect = new(0, 0, viewportWidth, viewportHeight);
+        if (!destRect.IntersectsWith(viewportRect))
+        {
+            return;
+        }
+
+        SKRect clippedDest = SKRect.Intersect(destRect, viewportRect);
+        float invScaleX = bitmap.Width / width;
+        float invScaleY = bitmap.Height / height;
+        SKRect sourceRect = new(
+            (clippedDest.Left - destRect.Left) * invScaleX,
+            (clippedDest.Top - destRect.Top) * invScaleY,
+            (clippedDest.Right - destRect.Left) * invScaleX,
+            (clippedDest.Bottom - destRect.Top) * invScaleY);
+
         SKPaint paint = overridePaint ?? _spritePaint;
         paint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
-        canvas.DrawBitmap(bitmap, new SKRect(x, y, x + width, y + height), paint);
+        canvas.DrawBitmap(bitmap, sourceRect, clippedDest, paint);
     }
 
     private static bool IsNudgeKey(Windows.System.VirtualKey key)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -597,12 +597,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
         return bmp;
     }
 
-    private void CoordinateCanvas_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    private void CoordinateCanvas_PaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
     {
         DrawCanvas(e.Surface.Canvas, e.Info.Width, e.Info.Height, true);
     }
 
-    private void AnimationPreviewCanvas_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    private void AnimationPreviewCanvas_PaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
     {
         DrawCanvas(e.Surface.Canvas, e.Info.Width, e.Info.Height, false);
     }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -7,6 +7,7 @@ using SkiaSharp;
 using SkiaSharp.Views.Windows;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -130,13 +131,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public void SetSpriteIndex(int index)
     {
         _selectedFrame = index;
+        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
+        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
 
         OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
         OffsetYTextBox.Value = _animationConfig.frameCongfigs[index].Offset.Y;
-        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
+        
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
-
-        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
 
         UpdateVisuals();
@@ -177,6 +178,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void UpdateVisuals()
     {
+    
         CoordinateCanvas.Invalidate();
         UpdateZoomControls();
     }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -267,6 +267,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double newAxisY = point.Position.Y + (worldY * newZoom);
 
         _pan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
+        if (_isDragging)
+        {
+            _dragStartPan = _pan;
+            _dragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        }
         UpdateVisuals();
         e.Handled = true;
     }
@@ -506,6 +511,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
         double newAxisX = point.Position.X - (worldX * newZoom);
         double newAxisY = point.Position.Y + (worldY * newZoom);
         _previewPan = new Vector2((float)(newAxisX - centerX), (float)(newAxisY - centerY));
+        if (_isPreviewDragging)
+        {
+            _previewDragStartPan = _previewPan;
+            _previewDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        }
 
         UpdateAnimationPreviewFrame();
         e.Handled = true;
@@ -582,20 +592,20 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         if (main)
         {
-            SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
-            if (currentFrame != null)
-            {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
-            }
-
             if (ShowPreviousToggleSwitch.IsOn)
             {
                 int previousFrameIndex = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
                 SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f, _previousFramePaint);
+                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, 0.5f, _previousFramePaint);
                 }
+            }
+
+            SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
+            if (currentFrame != null)
+            {
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
             }
         }
         else
@@ -614,16 +624,15 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void DrawCheckerboard(SKCanvas canvas, int width, int height, float axisX, float axisY, float zoom)
     {
-        _checkerboardShader?.Dispose();
         float tileSize = Math.Max(1f, 4f * zoom);
-        SKMatrix shaderMatrix = SKMatrix.CreateScaleTranslation(tileSize, tileSize, axisX, axisY);
-        _checkerboardShader = _checkerboardUnitBitmap.ToShader(
-            SKShaderTileMode.Repeat,
-            SKShaderTileMode.Repeat,
-            new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None),
-            shaderMatrix);
         _checkerboardPaint.Shader = _checkerboardShader;
-        canvas.DrawRect(new SKRect(0f, 0f, width, height), _checkerboardPaint);
+        canvas.Save();
+        canvas.Translate(axisX, axisY);
+        canvas.Scale(tileSize, tileSize);
+        canvas.DrawRect(
+            new SKRect(-axisX / tileSize, -axisY / tileSize, (width - axisX) / tileSize, (height - axisY) / tileSize),
+            _checkerboardPaint);
+        canvas.Restore();
     }
 
     private void DrawFrame(SKCanvas canvas, SKBitmap bitmap, IntVector2 offset, float zoom, float axisX, float axisY, float alpha, SKPaint? overridePaint = null)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -131,12 +131,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         _selectedFrame = index;
 
+        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
+        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
         OffsetYTextBox.Value = _animationConfig.frameCongfigs[index].Offset.Y;
-        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
-
-        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
 
         UpdateVisuals();
@@ -597,20 +596,22 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         if (main)
         {
-            if (ShowPreviousToggleSwitch.IsOn)
+            bool isInteracting = _isDragging || _isFrameDragging;
+            bool showPrevious = ShowPreviousToggleSwitch.IsOn && !isInteracting;
+            if (showPrevious)
             {
                 int previousFrameIndex = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
                 SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
+                    DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
                 }
             }
 
             SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, showPrevious ? 0.7f : 1f);
             }
         }
         else

--- a/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
+++ b/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.Views.WinUI" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.Views.Windows" Version="3.119.2" />
     <PackageReference Include="System.Windows.Extensions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
+++ b/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.Views.Windows" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="3.119.2" />
     <PackageReference Include="System.Windows.Extensions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
+++ b/FramesToMMSpriteResources/FramesToMMSpriteResources.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.Views.Windows" Version="3.119.2" />
     <PackageReference Include="System.Windows.Extensions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -290,7 +290,7 @@ namespace FramesToMMSpriteResources
         {
             if (_waitingForSecondaryActivation)
             {
-                Debug.WriteLine("ACTIVATED WITH SECONDARY SOLUTION");
+
                 ActivateProgram();
                 _ableToRelaod = true;
             }
@@ -323,11 +323,11 @@ namespace FramesToMMSpriteResources
             {
                 if (!_ableToRelaod)
                 {
-                    Debug.WriteLine("TREID TO ACTIVATE");
+
                     _waitingForSecondaryActivation = true;
                     return;
                 }
-                Debug.WriteLine("ACTIVATED AS IT SHOULD");
+
                 ActivateProgram();
             }
             else
@@ -338,7 +338,7 @@ namespace FramesToMMSpriteResources
                 if (!_waitingForSecondaryActivation)
                 {
                     _waitingForSecondaryActivation = false;
-                    Debug.WriteLine("DEACTIVATED");
+           
                     _isWindowActive = false;
                     CheckForAllowProgramEditing();
                     cts?.Cancel();
@@ -353,7 +353,7 @@ namespace FramesToMMSpriteResources
                 else
                 {
                     _waitingForSecondaryActivation = false;
-                    Debug.WriteLine("TRIED TO DEACTIVATE");
+ 
                 }
                 
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -142,6 +142,10 @@ namespace FramesToMMSpriteResources
 
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
+        private readonly DispatcherTimer _frameScrollHoldTimer = new();
+        private Windows.System.VirtualKey? _heldFrameScrollKey;
+        private int _frameScrollHoldTicks;
+        private const int FrameScrollHoldDelayTicks = 8;
 
         private bool _isGeneratePanelShowed = true;
 
@@ -246,6 +250,8 @@ namespace FramesToMMSpriteResources
         public MainWindow()
         {
             InitializeComponent();
+            _frameScrollHoldTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
+            _frameScrollHoldTimer.Tick += FrameScrollHoldTimer_Tick;
 
             AppWindow.Resize(new Windows.Graphics.SizeInt32(1000, 625));
             AppWindow.SetIcon("Assets/icon.ico");
@@ -2048,6 +2054,15 @@ namespace FramesToMMSpriteResources
             }
 
             FrameCoordinateEditorControl.HandleNudgeKeyUp(e.Key);
+            if (e.Key == Windows.System.VirtualKey.Q || e.Key == Windows.System.VirtualKey.E)
+            {
+                if (_heldFrameScrollKey == e.Key)
+                {
+                    _heldFrameScrollKey = null;
+                    _frameScrollHoldTicks = 0;
+                    _frameScrollHoldTimer.Stop();
+                }
+            }
         }
 
         private bool HandleTreeViewHotkeys(KeyRoutedEventArgs e)
@@ -2123,31 +2138,58 @@ namespace FramesToMMSpriteResources
             {
                 return false;
             }
+            int direction = e.Key == Windows.System.VirtualKey.Q ? -1 : 1;
+            _ = StepSelectedSibling(direction);
+            _heldFrameScrollKey = e.Key;
+            _frameScrollHoldTicks = 0;
+            if (!_frameScrollHoldTimer.IsEnabled)
+            {
+                _frameScrollHoldTimer.Start();
+            }
+            return true;
+        }
+
+        private void FrameScrollHoldTimer_Tick(object? sender, object e)
+        {
+            if (_heldFrameScrollKey is not Windows.System.VirtualKey key)
+            {
+                _frameScrollHoldTimer.Stop();
+                _frameScrollHoldTicks = 0;
+                return;
+            }
+
+            _frameScrollHoldTicks++;
+            if (_frameScrollHoldTicks < FrameScrollHoldDelayTicks)
+            {
+                return;
+            }
+
+            _ = StepSelectedSibling(key == Windows.System.VirtualKey.Q ? -1 : 1);
+        }
+
+        private bool StepSelectedSibling(int direction)
+        {
+            TreeViewNode? selectedNode = TreeViewControl.SelectedNode;
+            if (selectedNode == null)
+            {
+                return false;
+            }
 
             IList<TreeViewNode> siblingList = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
-            int currentIndex = -1;
-            for (int i = 0; i < siblingList.Count; i++)
-            {
-                if (siblingList[i] == selectedNode)
-                {
-                    currentIndex = i;
-                    break;
-                }
-            }
+            int currentIndex = siblingList.IndexOf(selectedNode);
             if (currentIndex < 0)
             {
                 return false;
             }
 
-            int newIndex = e.Key == Windows.System.VirtualKey.Q ? currentIndex - 1 : currentIndex + 1;
+            int newIndex = currentIndex + direction;
             if (newIndex < 0 || newIndex >= siblingList.Count)
             {
-                return true;
+                return false;
             }
 
             TreeViewControl.SelectedNode = siblingList[newIndex];
             ChangeConfigPanel(siblingList[newIndex], false);
-     
             return true;
         }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -142,10 +142,6 @@ namespace FramesToMMSpriteResources
 
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
-        private readonly DispatcherTimer _frameScrollHoldTimer = new();
-        private Windows.System.VirtualKey? _heldFrameScrollKey;
-        private int _frameScrollHoldTicks;
-        private const int FrameScrollHoldDelayTicks = 8;
 
         private bool _isGeneratePanelShowed = true;
 
@@ -250,8 +246,6 @@ namespace FramesToMMSpriteResources
         public MainWindow()
         {
             InitializeComponent();
-            _frameScrollHoldTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
-            _frameScrollHoldTimer.Tick += FrameScrollHoldTimer_Tick;
 
             AppWindow.Resize(new Windows.Graphics.SizeInt32(1000, 625));
             AppWindow.SetIcon("Assets/icon.ico");
@@ -2054,15 +2048,6 @@ namespace FramesToMMSpriteResources
             }
 
             FrameCoordinateEditorControl.HandleNudgeKeyUp(e.Key);
-            if (e.Key == Windows.System.VirtualKey.Q || e.Key == Windows.System.VirtualKey.E)
-            {
-                if (_heldFrameScrollKey == e.Key)
-                {
-                    _heldFrameScrollKey = null;
-                    _frameScrollHoldTicks = 0;
-                    _frameScrollHoldTimer.Stop();
-                }
-            }
         }
 
         private bool HandleTreeViewHotkeys(KeyRoutedEventArgs e)
@@ -2138,58 +2123,31 @@ namespace FramesToMMSpriteResources
             {
                 return false;
             }
-            int direction = e.Key == Windows.System.VirtualKey.Q ? -1 : 1;
-            _ = StepSelectedSibling(direction);
-            _heldFrameScrollKey = e.Key;
-            _frameScrollHoldTicks = 0;
-            if (!_frameScrollHoldTimer.IsEnabled)
-            {
-                _frameScrollHoldTimer.Start();
-            }
-            return true;
-        }
-
-        private void FrameScrollHoldTimer_Tick(object? sender, object e)
-        {
-            if (_heldFrameScrollKey is not Windows.System.VirtualKey key)
-            {
-                _frameScrollHoldTimer.Stop();
-                _frameScrollHoldTicks = 0;
-                return;
-            }
-
-            _frameScrollHoldTicks++;
-            if (_frameScrollHoldTicks < FrameScrollHoldDelayTicks)
-            {
-                return;
-            }
-
-            _ = StepSelectedSibling(key == Windows.System.VirtualKey.Q ? -1 : 1);
-        }
-
-        private bool StepSelectedSibling(int direction)
-        {
-            TreeViewNode? selectedNode = TreeViewControl.SelectedNode;
-            if (selectedNode == null)
-            {
-                return false;
-            }
 
             IList<TreeViewNode> siblingList = selectedNode.Parent?.Children ?? TreeViewControl.RootNodes;
-            int currentIndex = siblingList.IndexOf(selectedNode);
+            int currentIndex = -1;
+            for (int i = 0; i < siblingList.Count; i++)
+            {
+                if (siblingList[i] == selectedNode)
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
             if (currentIndex < 0)
             {
                 return false;
             }
 
-            int newIndex = currentIndex + direction;
+            int newIndex = e.Key == Windows.System.VirtualKey.Q ? currentIndex - 1 : currentIndex + 1;
             if (newIndex < 0 || newIndex >= siblingList.Count)
             {
-                return false;
+                return true;
             }
 
             TreeViewControl.SelectedNode = siblingList[newIndex];
             ChangeConfigPanel(siblingList[newIndex], false);
+     
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- The previous UI used layered XAML `Image`/`Rectangle` elements and scaled `WriteableBitmap` sources which introduced filtering artifacts when zooming and made pixel-art sprites blurrier than desired. 
- A single, high-performance canvas render pipeline using SkiaSharp ensures nearest-neighbor sampling and faster, consistent compositing for checkerboard, axes, and sprite layers. 

### Description
- Replaced the main editor and preview `Canvas`/`Image` stack with `SKXamlCanvas` elements and moved rendering into `PaintSurface` handlers so the checkerboard, axes, current/previous sprites, and preview are drawn in one Skia pass. 
- Implemented nearest-neighbor sprite drawing by configuring an `SKPaint` with `FilterQuality.None` and disabling antialiasing so zoomed sprites remain sharply pixelated. 
- Added `WriteableBitmap` → `SKBitmap` caching to avoid repeated conversions and reduce per-frame work during pan/zoom/drag operations, and consolidated frame drawing logic (`DrawCanvas` / `DrawFrame`). 
- Updated XAML and project dependencies to include `SkiaSharp.Views.Windows` and adjusted editor logic (e.g. `UpdateVisuals()`, preview invalidation, and `ShowPrevious` toggle) to trigger Skia redraws instead of manipulating removed XAML image elements. 

### Testing
- Attempted to build with `dotnet build FramesToMMSpriteResources/FramesToMMSpriteResources.csproj -v minimal`, but the build could not be run in this environment because the `dotnet` CLI is not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e76d0a5c8327ae61b42f2718c7dc)