### PR TITLE
Make AnimationPreviewCanvas resizable from left, bottom, and bottom-left corner

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -52,7 +52,6 @@
                                 Width="8"
                                 HorizontalAlignment="Left"
                                 Background="Transparent"
-                                Cursor="SizeWestEast"
                                 PointerPressed="PreviewResizeLeftHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>
@@ -60,7 +59,6 @@
                                 Height="8"
                                 VerticalAlignment="Bottom"
                                 Background="Transparent"
-                                Cursor="SizeNorthSouth"
                                 PointerPressed="PreviewResizeBottomHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>
@@ -70,7 +68,6 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Bottom"
                                 Background="Transparent"
-                                Cursor="SizeNorthwestSoutheast"
                                 PointerPressed="PreviewResizeCornerHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -52,6 +52,8 @@
                                 Width="8"
                                 HorizontalAlignment="Left"
                                 Background="Transparent"
+                                PointerEntered="PreviewResizeLeftHandle_PointerEntered"
+                                PointerExited="PreviewResizeHandle_PointerExited"
                                 PointerPressed="PreviewResizeLeftHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>
@@ -59,6 +61,8 @@
                                 Height="8"
                                 VerticalAlignment="Bottom"
                                 Background="Transparent"
+                                PointerEntered="PreviewResizeBottomHandle_PointerEntered"
+                                PointerExited="PreviewResizeHandle_PointerExited"
                                 PointerPressed="PreviewResizeBottomHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>
@@ -68,6 +72,8 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Bottom"
                                 Background="Transparent"
+                                PointerEntered="PreviewResizeCornerHandle_PointerEntered"
+                                PointerExited="PreviewResizeHandle_PointerExited"
                                 PointerPressed="PreviewResizeCornerHandle_PointerPressed"
                                 PointerMoved="PreviewResizeHandle_PointerMoved"
                                 PointerReleased="PreviewResizeHandle_PointerReleased"/>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -13,7 +13,7 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <Border Margin="20 20 10 90" Grid.Column="0" CornerRadius="8" Padding="0" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
+        <Border Margin="20 20 10 90" Grid.Column="0" Padding="0" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
             <Grid>
                 <skia:SKSwapChainPanel x:Name="CoordinateCanvas"
                         HorizontalAlignment="Stretch"
@@ -25,21 +25,27 @@
                         PointerReleased="CoordinateCanvas_PointerReleased"
                         PointerWheelChanged="CoordinateCanvas_PointerWheelChanged"/>
                 <StackPanel
-                    Margin="10"
+                    Margin="-4 10 10 0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top">
                 <Border 
                         x:Name="AnimationPreviewHostBorder"
-                        CornerRadius="8 8 0 8"
-                        Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                        BorderBrush="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
-                        BorderThickness="1"
-                        Width="220"
-                        Height="220"
-                        MinWidth="150"
-                        MinHeight="175">
+        
+                            
+                        Width="126"
+                        Height="156"
+                        MinWidth="126"
+                        MinHeight="126">
                     <Grid>
-                        <skia:SKSwapChainPanel x:Name="AnimationPreviewCanvas"
+                        <Border 
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch"
+                            Margin="4 0 0 4"
+                            BorderThickness="1"
+               
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
+                            <skia:SKSwapChainPanel x:Name="AnimationPreviewCanvas"
+                                               
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 PaintSurface="AnimationPreviewCanvas_PaintSurface"
@@ -48,8 +54,10 @@
                                 PointerMoved="AnimationPreviewCanvas_PointerMoved"
                                 PointerReleased="AnimationPreviewCanvas_PointerReleased"
                                 PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged"/>
+                        </Border>
                         <Border x:Name="PreviewResizeLeftHandle"
                                 Width="8"
+                          
                                 HorizontalAlignment="Left"
                                 Background="Transparent"
                                 PointerEntered="PreviewResizeLeftHandle_PointerEntered"
@@ -85,7 +93,7 @@
                         CornerRadius="0 0 8 8"
                         Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
                         BorderBrush="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
-                        Margin="0 -2 0 0"
+                        Margin="0 -6 0 0"
                         BorderThickness="1"
                         HorizontalAlignment="Right">
                         
@@ -186,6 +194,21 @@
                                 <FontIcon Glyph="&#xEA4F;" FontSize="12"/>
                             </Button>
                         </Grid>
+                        <Grid ColumnSpacing="10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                
+                            </Grid.ColumnDefinitions>
+                            <NumberBox Grid.Column="0" x:Name="DirectionNumberBox" Header="Direction" PlaceholderText="90" Minimum="-999999" Maximum="999999"/>
+                            <NumberBox Grid.Column="1" x:Name="SpeedNumberBox" Header="Speed (p/f)" PlaceholderText="0" Minimum="-999999" Maximum="999999"/>
+                       
+                        </Grid>
+                        <Button Grid.Column="2" HorizontalAlignment="Stretch" Height="32" Click="RemoveMovementButton_Click">
+                          
+                                <TextBlock Text="Remove movement"/>
+                           
+                        </Button>
                     </StackPanel>
                 </Border>
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -29,16 +29,16 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top">
                 <Border 
-                        
-                      
+                        x:Name="AnimationPreviewHostBorder"
                         CornerRadius="8 8 0 8"
                         Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
                         BorderBrush="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
                         BorderThickness="1"
-                    MinWidth="150"
-                    MinHeight="175">
-                        
-
+                        Width="220"
+                        Height="220"
+                        MinWidth="150"
+                        MinHeight="175">
+                    <Grid>
                         <skia:SKSwapChainPanel x:Name="AnimationPreviewCanvas"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
@@ -48,7 +48,33 @@
                                 PointerMoved="AnimationPreviewCanvas_PointerMoved"
                                 PointerReleased="AnimationPreviewCanvas_PointerReleased"
                                 PointerWheelChanged="AnimationPreviewCanvas_PointerWheelChanged"/>
-                 
+                        <Border x:Name="PreviewResizeLeftHandle"
+                                Width="8"
+                                HorizontalAlignment="Left"
+                                Background="Transparent"
+                                Cursor="SizeWestEast"
+                                PointerPressed="PreviewResizeLeftHandle_PointerPressed"
+                                PointerMoved="PreviewResizeHandle_PointerMoved"
+                                PointerReleased="PreviewResizeHandle_PointerReleased"/>
+                        <Border x:Name="PreviewResizeBottomHandle"
+                                Height="8"
+                                VerticalAlignment="Bottom"
+                                Background="Transparent"
+                                Cursor="SizeNorthSouth"
+                                PointerPressed="PreviewResizeBottomHandle_PointerPressed"
+                                PointerMoved="PreviewResizeHandle_PointerMoved"
+                                PointerReleased="PreviewResizeHandle_PointerReleased"/>
+                        <Border x:Name="PreviewResizeCornerHandle"
+                                Width="14"
+                                Height="14"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom"
+                                Background="Transparent"
+                                Cursor="SizeNorthwestSoutheast"
+                                PointerPressed="PreviewResizeCornerHandle_PointerPressed"
+                                PointerMoved="PreviewResizeHandle_PointerMoved"
+                                PointerReleased="PreviewResizeHandle_PointerReleased"/>
+                    </Grid>
                 </Border>
                     <Border
                    

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -47,11 +47,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private double _previewResizeStartWidth;
     private double _previewResizeStartHeight;
     private Vector2 _previewResizeStartPointer;
-    private const double MinPreviewPanelWidth = 150;
-    private const double MinPreviewPanelHeight = 175;
+    private const double MinPreviewPanelWidth = 126;
+    private const double MinPreviewPanelHeight = 126;
     private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
-    private readonly InputCursor _resizeCornerCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthwestSoutheast);
+    private readonly InputCursor _resizeCornerCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNortheastSouthwest);
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
@@ -64,6 +64,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
+
+
+    public event Action<float, float>? RemoveMovementButtonClick;
+
     private enum ResizeDirection
     {
         None,
@@ -160,6 +164,18 @@ public sealed partial class FrameCoordinateEditor : UserControl
         UpdateVisuals();
     }
 
+    public void RefreshOffsetFieldVisually()
+    {
+        OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
+        OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
+
+        OffsetXTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.X;
+        OffsetYTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.Y;
+
+        OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
+        OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
+    }
+
     public void LoadAnimation(IReadOnlyList<WriteableBitmap> frames, AnimationConfig animationConfig)
     {
         _previewFrames = frames;
@@ -191,6 +207,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public void UnloadAnimation()
     {
         LoadAnimation([], new());
+        UpdateVisuals();
     }
 
     private void UpdateVisuals()
@@ -701,9 +718,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         DrawCheckerboard(canvas, width, height, axisX, axisY, zoom);
 
-        _axisPaint.StrokeWidth = main ? 1.5f : 1f;
-        canvas.DrawLine(0f, axisY, width, axisY, _axisPaint);
-        canvas.DrawLine(axisX, 0f, axisX, height, _axisPaint);
+
+
 
         if (_previewFrames.Count == 0)
         {
@@ -740,6 +756,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 DrawFrame(canvas, previewFrame, previewOffset, zoom, axisX, axisY, width, height, 1f);
             }
         }
+
+        _axisPaint.StrokeWidth = main ? 1.5f : 1f;
+        canvas.DrawLine(0f, axisY, width, axisY, _axisPaint);
+        canvas.DrawLine(axisX, 0f, axisX, height, _axisPaint);
     }
 
     private void DrawCheckerboard(SKCanvas canvas, int width, int height, float axisX, float axisY, float zoom)
@@ -846,6 +866,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
                _heldNudgeKeys.Contains(Windows.System.VirtualKey.A) ||
                _heldNudgeKeys.Contains(Windows.System.VirtualKey.S) ||
                _heldNudgeKeys.Contains(Windows.System.VirtualKey.D);
+    }
+
+    private void RemoveMovementButton_Click(object sender, RoutedEventArgs e)
+    {
+        RemoveMovementButtonClick?.Invoke((float)DirectionNumberBox.Value, (float)SpeedNumberBox.Value);
+        
+        UpdateVisuals();
+        
     }
 
     private void NudgeHoldTimer_Tick(object? sender, object e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -1,9 +1,9 @@
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.UI.Core;
 using SkiaSharp;
 using SkiaSharp.Views.Windows;
 using System;
@@ -49,9 +49,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _previewResizeStartPointer;
     private const double MinPreviewPanelWidth = 150;
     private const double MinPreviewPanelHeight = 175;
-    private readonly CoreCursor _resizeLeftCursor = new(CoreCursorType.SizeWestEast, 0);
-    private readonly CoreCursor _resizeBottomCursor = new(CoreCursorType.SizeNorthSouth, 0);
-    private readonly CoreCursor _resizeCornerCursor = new(CoreCursorType.SizeNorthwestSoutheast, 0);
+    private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
+    private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
+    private readonly InputCursor _resizeCornerCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthwestSoutheast);
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -42,6 +42,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private bool _isPreviewDragging;
     private Vector2 _previewDragStartPointer;
     private Vector2 _previewDragStartPan;
+    private ResizeDirection _previewResizeDirection;
+    private double _previewResizeStartWidth;
+    private double _previewResizeStartHeight;
+    private Vector2 _previewResizeStartPointer;
+    private const double MinPreviewPanelWidth = 150;
+    private const double MinPreviewPanelHeight = 175;
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
@@ -54,6 +60,13 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
+    private enum ResizeDirection
+    {
+        None,
+        Left,
+        Bottom,
+        BottomLeft
+    }
 
     public FrameCoordinateEditor()
     {
@@ -460,6 +473,11 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void AnimationPreviewCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        if (_previewResizeDirection != ResizeDirection.None)
+        {
+            return;
+        }
+
         var point = e.GetCurrentPoint(AnimationPreviewCanvas);
         _previewDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _previewDragStartPan = _previewPan;
@@ -486,6 +504,76 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         _isPreviewDragging = false;
         AnimationPreviewCanvas.ReleasePointerCapture(e.Pointer);
+    }
+
+    private void PreviewResizeLeftHandle_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        StartPreviewResize(sender, e, ResizeDirection.Left);
+    }
+
+    private void PreviewResizeBottomHandle_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        StartPreviewResize(sender, e, ResizeDirection.Bottom);
+    }
+
+    private void PreviewResizeCornerHandle_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        StartPreviewResize(sender, e, ResizeDirection.BottomLeft);
+    }
+
+    private void StartPreviewResize(object sender, PointerRoutedEventArgs e, ResizeDirection direction)
+    {
+        if (sender is not UIElement handle)
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(this);
+        _previewResizeDirection = direction;
+        _previewResizeStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
+        _previewResizeStartWidth = AnimationPreviewHostBorder.ActualWidth;
+        _previewResizeStartHeight = AnimationPreviewHostBorder.ActualHeight;
+        handle.CapturePointer(e.Pointer);
+        e.Handled = true;
+    }
+
+    private void PreviewResizeHandle_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_previewResizeDirection == ResizeDirection.None)
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(this);
+        var delta = new Vector2((float)point.Position.X, (float)point.Position.Y) - _previewResizeStartPointer;
+        double width = _previewResizeStartWidth;
+        double height = _previewResizeStartHeight;
+
+        if (_previewResizeDirection is ResizeDirection.Left or ResizeDirection.BottomLeft)
+        {
+            width = Math.Max(MinPreviewPanelWidth, _previewResizeStartWidth - delta.X);
+        }
+
+        if (_previewResizeDirection is ResizeDirection.Bottom or ResizeDirection.BottomLeft)
+        {
+            height = Math.Max(MinPreviewPanelHeight, _previewResizeStartHeight + delta.Y);
+        }
+
+        AnimationPreviewHostBorder.Width = width;
+        AnimationPreviewHostBorder.Height = height;
+        UpdateAnimationPreviewFrame();
+        e.Handled = true;
+    }
+
+    private void PreviewResizeHandle_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement handle)
+        {
+            handle.ReleasePointerCapture(e.Pointer);
+        }
+
+        _previewResizeDirection = ResizeDirection.None;
+        e.Handled = true;
     }
 
     private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.UI.Core;
 using SkiaSharp;
 using SkiaSharp.Views.Windows;
 using System;
@@ -48,6 +49,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private Vector2 _previewResizeStartPointer;
     private const double MinPreviewPanelWidth = 150;
     private const double MinPreviewPanelHeight = 175;
+    private readonly CoreCursor _resizeLeftCursor = new(CoreCursorType.SizeWestEast, 0);
+    private readonly CoreCursor _resizeBottomCursor = new(CoreCursorType.SizeNorthSouth, 0);
+    private readonly CoreCursor _resizeCornerCursor = new(CoreCursorType.SizeNorthwestSoutheast, 0);
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
@@ -510,15 +514,35 @@ public sealed partial class FrameCoordinateEditor : UserControl
     {
         StartPreviewResize(sender, e, ResizeDirection.Left);
     }
+    private void PreviewResizeLeftHandle_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        ProtectedCursor = _resizeLeftCursor;
+    }
 
     private void PreviewResizeBottomHandle_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
         StartPreviewResize(sender, e, ResizeDirection.Bottom);
     }
+    private void PreviewResizeBottomHandle_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        ProtectedCursor = _resizeBottomCursor;
+    }
 
     private void PreviewResizeCornerHandle_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
         StartPreviewResize(sender, e, ResizeDirection.BottomLeft);
+    }
+    private void PreviewResizeCornerHandle_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        ProtectedCursor = _resizeCornerCursor;
+    }
+
+    private void PreviewResizeHandle_PointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (_previewResizeDirection == ResizeDirection.None)
+        {
+            ProtectedCursor = null;
+        }
     }
 
     private void StartPreviewResize(object sender, PointerRoutedEventArgs e, ResizeDirection direction)
@@ -573,6 +597,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _previewResizeDirection = ResizeDirection.None;
+        ProtectedCursor = null;
         e.Handled = true;
     }
 

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -285,7 +285,45 @@ namespace FramesToMMSpriteResources
                     new PointerEventHandler(MainWindow_PointerPressed),
                     handledEventsToo: true);
             }
+
+            FrameCoordinateEditorControl.RemoveMovementButtonClick -= RemoveMovementButton_Click;
+            FrameCoordinateEditorControl.RemoveMovementButtonClick += RemoveMovementButton_Click;
         }
+
+        private void RemoveMovementButton_Click(float direaction, float speed)
+        {
+            var node = TreeViewControl.SelectedNode;
+            var gameThemeName = (node.Parent.Parent.Parent.Content as TreeItem)!.Text;
+            var subjectName = (node.Parent.Parent.Content as TreeItem)!.Text;
+            var animationNode = node.Parent;
+            var animationName = (animationNode.Content as TreeItem)!.Text;
+          
+            List<FrameConfig> frameConfigList = ProgramConfig.GameThemeConfigs[gameThemeName].SubjectConfigs[subjectName].AnimationConfigs[animationName].frameCongfigs;
+
+            Vector2? initialPosition = null;
+            for (int i = 0; i < animationNode.Children.Count; i++)
+            {
+                var frameNodeContent = (animationNode.Children[i].Content as TreeItem)!;
+                if (frameNodeContent.IsSelected)
+                {
+                   
+                    if (initialPosition == null)
+                    {
+                        initialPosition = new(frameConfigList[i].Offset.X, frameConfigList[i].Offset.Y);
+                    }
+                    else
+                    {
+                        initialPosition -= new Vector2(speed, 0f);
+                        frameConfigList[i].Offset = new((int)Math.Round(initialPosition.Value.X), (int)Math.Round(initialPosition.Value.Y));
+                    }
+                }
+            }
+            if((node.Content as TreeItem).Text != "000")
+            {
+                FrameCoordinateEditorControl.RefreshOffsetFieldVisually();
+            }
+        }
+
         private void MainWindow_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
             if (_waitingForSecondaryActivation)


### PR DESCRIPTION
### Motivation
- Allow the animation preview to be resized like a window by dragging its left edge, bottom edge, or bottom-left corner so users can adjust preview size interactively.

### Description
- Wrapped the preview `SKSwapChainPanel` in a named host `Border` (`AnimationPreviewHostBorder`) and gave it explicit `Width`/`Height` while preserving `MinWidth`/`MinHeight` constraints in `FrameCoordinateEditor.xaml`.
- Added three transparent resize handles (`PreviewResizeLeftHandle`, `PreviewResizeBottomHandle`, `PreviewResizeCornerHandle`) inside a `Grid` overlay and wired pointer events plus appropriate resize cursors in XAML.
- Implemented resize logic in `FrameCoordinateEditor.xaml.cs` including a `ResizeDirection` enum, resize state fields, `StartPreviewResize`, `PreviewResizeHandle_PointerMoved`, and release handlers, and applied new width/height to the host border during drag.
- Prevented preview pan gestures from starting while a resize is active by short-circuiting preview drag start when `_previewResizeDirection` is not `None`, and call `UpdateAnimationPreviewFrame()` after size changes.

### Testing
- Attempted automated build with `dotnet build FramesToMMSpriteResources.slnx`, but the build step failed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0d9f94ac8327a0af17f28f49ad12)