### PR TITLE
Apply subject-config background removal in frame editor canvases

### DIFF
--- a/FramesToMMSpriteResources/ColorHelper.cs
+++ b/FramesToMMSpriteResources/ColorHelper.cs
@@ -8,6 +8,17 @@ namespace FramesToMMSpriteResources
 {
     internal class ColorHelper
     {
+        public static bool IsWithinThreshold(byte pr, byte pg, byte pb, byte pa, byte r, byte g, byte b, byte a, int colorThreshold)
+        {
+            int dr = pr - r;
+            int dg = pg - g;
+            int db = pb - b;
+            int da = pa - a;
+            int dist2 = (dr * dr) + (dg * dg) + (db * db) + (da * da);
+            int thresholdSquared = colorThreshold * colorThreshold;
+            return dist2 <= thresholdSquared;
+        }
+
         public static bool TryParse(string? input, out byte a, out byte r, out byte g, out byte b)
         {
             a = r = g = b = 0;

--- a/FramesToMMSpriteResources/ColorHelper.cs
+++ b/FramesToMMSpriteResources/ColorHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SkiaSharp;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +9,27 @@ namespace FramesToMMSpriteResources
 {
     internal class ColorHelper
     {
+        public static void RemoveColorWithThresholdInPlace(SKBitmap bitmap, byte r, byte g, byte b, byte a, int colorThreshold)
+        {
+            var pixels = bitmap.GetPixelSpan();
+            int length = pixels.Length;
+
+            for (int i = 0; i < length; i += 4)
+            {
+                byte pb = pixels[i + 0];
+                byte pg = pixels[i + 1];
+                byte pr = pixels[i + 2];
+                byte pa = pixels[i + 3];
+
+                if (IsWithinThreshold(pr, pg, pb, pa, r, g, b, a, colorThreshold))
+                {
+                    pixels[i + 3] = 0;
+                }
+            }
+
+            bitmap.NotifyPixelsChanged();
+        }
+
         public static bool IsWithinThreshold(byte pr, byte pg, byte pb, byte pa, byte r, byte g, byte b, byte a, int colorThreshold)
         {
             int dr = pr - r;

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml
@@ -203,7 +203,7 @@
                     <StackPanel Spacing="12">
                         <TextBlock Text="Options" Style="{StaticResource SectionHeaderStyle}"/>
                         <Rectangle Style="{StaticResource GroupDividerStyle}"/>
-                        <ToggleSwitch Header="Remove background" Margin="0 0 0 -8"/>
+                        <ToggleSwitch x:Name="RemoveBackgroundToggleSwitch" Header="Remove background" Toggled="RemoveBackgroundToggleSwitch_Toggled" Margin="0 0 0 -8"/>
                         <ToggleSwitch Header="Crop" Margin="0 0 0 -8"/>
                         <ToggleSwitch x:Name="ShowPreviousToggleSwitch" Header="Show previous frame behind" Toggled="ShowPreviousToggleSwitch_Toggled" IsOn="True" Margin="0 0 0 -8"/>
                     </StackPanel>

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -756,21 +756,27 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return cached;
         }
 
-        SKBitmap masked = new(source.Width, source.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
-        double thresholdSquared = _colorThreshold * _colorThreshold;
-        SKColor bg = _backgroundColor.Value;
-        SKColor[] srcPixels = source.Pixels;
-        SKColor[] dstPixels = masked.Pixels;
-        for (int i = 0; i < srcPixels.Length; i++)
+        SKBitmap masked = source.Copy();
+        if (masked == null)
         {
-            SKColor px = srcPixels[i];
-            int dr = px.Red - bg.Red;
-            int dg = px.Green - bg.Green;
-            int db = px.Blue - bg.Blue;
-            int da = px.Alpha - bg.Alpha;
-            double dist2 = (dr * dr) + (dg * dg) + (db * db) + (da * da);
-            dstPixels[i] = dist2 <= thresholdSquared ? new SKColor(0, 0, 0, 0) : px;
+            return source;
         }
+
+        SKColor bg = _backgroundColor.Value;
+        byte[] pixels = masked.Bytes;
+        for (int i = 0; i < pixels.Length; i += 4)
+        {
+            byte pb = pixels[i + 0];
+            byte pg = pixels[i + 1];
+            byte pr = pixels[i + 2];
+            byte pa = pixels[i + 3];
+
+            if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, bg.Red, bg.Green, bg.Blue, bg.Alpha, _colorThreshold))
+            {
+                pixels[i + 3] = 0;
+            }
+        }
+        masked.NotifyPixelsChanged();
 
         if (wb != null)
         {

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -35,7 +35,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private IReadOnlyList<WriteableBitmap> _previewFrames = [];
     private int _previewFrameIndex;
     private int _previewTickCount;
-    private AnimationConfig _animationConfig = new();
+    private SubjectConfig _subjectConfig = new();
+    private string? _animationConfigName = null;
     private Vector2 _previewPan = Vector2.Zero;
     private float _previewZoom = 1.0f;
     private const float MinPreviewZoom = 0.05f;
@@ -65,9 +66,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
-    private bool _removeBackground;
-    private SKColor? _backgroundColor;
-    private int _colorThreshold = 100;
 
 
     public event Action<float, float>? RemoveMovementButtonClick;
@@ -103,6 +101,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         ActualThemeChanged -= ThemeChanged;
         ActualThemeChanged += ThemeChanged;
+    }
+
+    AnimationConfig getCurrentAnimationConfig()
+    {
+        return _subjectConfig.AnimationConfigs![_animationConfigName!];
+    }
+
+    FrameConfig getCurrentFrameConfig()
+    {
+        return getCurrentAnimationConfig().frameCongfigs[_selectedFrame];
     }
 
     void ThemeChanged(FrameworkElement fe, object o)
@@ -160,8 +168,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
 
-        OffsetXTextBox.Value = _animationConfig.frameCongfigs[index].Offset.X;
-        OffsetYTextBox.Value = _animationConfig.frameCongfigs[index].Offset.Y;
+        OffsetXTextBox.Value = getCurrentFrameConfig().Offset.X;
+        OffsetYTextBox.Value = getCurrentFrameConfig().Offset.Y;
         
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
@@ -174,8 +182,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
 
-        OffsetXTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.X;
-        OffsetYTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.Y;
+        OffsetXTextBox.Value = getCurrentFrameConfig().Offset.X;
+        OffsetYTextBox.Value = getCurrentFrameConfig().Offset.Y;
 
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
@@ -198,7 +206,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         AnimationPreviewCanvas.PointerWheelChanged -= AnimationPreviewCanvas_PointerWheelChanged;
     }
 
-    public void LoadAnimation(IReadOnlyList<WriteableBitmap> frames, AnimationConfig animationConfig)
+    public void LoadAnimation(IReadOnlyList<WriteableBitmap> frames, SubjectConfig subjectConfig, string animationConfigName)
     {
         UnscubscribeCanvases();
 
@@ -212,7 +220,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
         _previewFrameIndex = 0;
         _previewTickCount = 0;
-        _animationConfig = animationConfig;
+        _subjectConfig = subjectConfig;
+        _animationConfigName = animationConfigName;
         int maxFrames = Math.Max(_previewFrames.Count - 1, 0);
         ToNumberBox.PlaceholderText = maxFrames.ToString();
         ToNumberBox.Maximum = maxFrames;
@@ -247,7 +256,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
     public void UnloadAnimation()
     {
         UnscubscribeCanvases();
-        LoadAnimation([], new());
+        LoadAnimation([], new(), null);
         UpdateVisuals();
     }
 
@@ -270,7 +279,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         if (point.Properties.IsLeftButtonPressed)
         {
             _frameDragStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
-            _frameDragStartOffset = _animationConfig.frameCongfigs[_selectedFrame].Offset;
+            _frameDragStartOffset = getCurrentFrameConfig().Offset;
             _isFrameDragging = true;
             CoordinateCanvas.CapturePointer(e.Pointer);
         }
@@ -303,7 +312,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
             int dx = (int)MathF.Round(delta.X / _zoom);
             int dy = (int)MathF.Round(-delta.Y / _zoom);
             IntVector2 newOffset = new(_frameDragStartOffset.X + dx, _frameDragStartOffset.Y + dy);
-            IntVector2 currentOffset = _animationConfig.frameCongfigs[_selectedFrame].Offset;
+            IntVector2 currentOffset = getCurrentFrameConfig().Offset;
             if (newOffset != currentOffset)
             {
                 NudgeOffset(newOffset.X - currentOffset.X, newOffset.Y - currentOffset.Y);
@@ -401,14 +410,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void OffsetXTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
 
-        SpritePositionChanged?.Invoke(new(double.IsNaN(sender.Value) ? 0 : (int)sender.Value, _animationConfig.frameCongfigs[_selectedFrame].Offset.Y));
+        SpritePositionChanged?.Invoke(new(double.IsNaN(sender.Value) ? 0 : (int)sender.Value, getCurrentFrameConfig().Offset.Y));
         UpdateVisuals();
 
     }
 
     private void OffsetYTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
-        SpritePositionChanged?.Invoke(new IntVector2(_animationConfig.frameCongfigs[_selectedFrame].Offset.X, double.IsNaN(sender.Value) ? 0 : (int)sender.Value));
+        SpritePositionChanged?.Invoke(new IntVector2(getCurrentFrameConfig().Offset.X, double.IsNaN(sender.Value) ? 0 : (int)sender.Value));
         UpdateVisuals();
 
     }
@@ -433,15 +442,15 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     public void NudgeOffset(int dx, int dy)
     {
-        if ((dx == 0 && dy == 0) || _animationConfig.frameCongfigs == null)
+        if ((dx == 0 && dy == 0) || getCurrentAnimationConfig().frameCongfigs == null)
         {
             return;
         }
 
         OffsetXTextBox.ValueChanged -= OffsetXTextBox_ValueChanged;
         OffsetYTextBox.ValueChanged -= OffsetYTextBox_ValueChanged;
-        OffsetXTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.X + dx;
-        OffsetYTextBox.Value = _animationConfig.frameCongfigs[_selectedFrame].Offset.Y + dy;
+        OffsetXTextBox.Value = getCurrentFrameConfig().Offset.X + dx;
+        OffsetYTextBox.Value = getCurrentFrameConfig().Offset.Y + dy;
         SpritePositionMoved?.Invoke(new(dx, dy));
         UpdateVisuals();
         OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
@@ -708,7 +717,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         _previewTickCount++;
-        if (_previewTickCount < _animationConfig.Delay)
+        if (_previewTickCount < getCurrentAnimationConfig().Delay)
         {
             return;
         }
@@ -746,7 +755,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return null;
         }
 
-        if (!_removeBackground || _backgroundColor == null)
+        if (!RemoveBackgroundToggleSwitch.IsOn || _subjectConfig.BackgroundColor == null)
         {
             return source;
         }
@@ -762,8 +771,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return source;
         }
 
-        SKColor bg = _backgroundColor.Value;
-        ColorHelper.RemoveColorWithThresholdInPlace(masked, bg.Red, bg.Green, bg.Blue, bg.Alpha, _colorThreshold);
+        ColorHelper.TryParse(_subjectConfig.BackgroundColor, out byte a, out byte r, out byte g, out byte b);
+        SKColor bg = new(r, g, b, a);
+        ColorHelper.RemoveColorWithThresholdInPlace(masked, bg.Red, bg.Green, bg.Blue, bg.Alpha, _subjectConfig.ColorTreshold);
 
         if (wb != null)
         {
@@ -771,34 +781,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         return masked;
-    }
-
-    public void SetBackgroundRemovalOptions(bool removeBackground, string? backgroundColorHex, int colorThreshold)
-    {
-        _removeBackground = removeBackground;
-        _colorThreshold = Math.Max(0, colorThreshold);
-        _backgroundColor = TryParseHexColor(backgroundColorHex, out SKColor parsedColor) ? parsedColor : null;
-        RemoveBackgroundToggleSwitch.IsOn = removeBackground;
-        _backgroundRemovedCache.Clear();
-        UpdateVisuals();
-        UpdateAnimationPreviewFrame();
-    }
-
-    private static bool TryParseHexColor(string? hex, out SKColor color)
-    {
-        color = default;
-        if (string.IsNullOrWhiteSpace(hex))
-        {
-            return false;
-        }
-
-        if (!ColorHelper.TryParse(hex, out byte a, out byte r, out byte g, out byte b))
-        {
-            return false;
-        }
-
-        color = new SKColor(r, g, b, a);
-        return true;
     }
 
     private void CoordinateCanvas_PaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
@@ -838,14 +820,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
                 SKBitmap? previousFrame = GetDisplayBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
-                DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
+                DrawFrame(canvas, previousFrame, getCurrentAnimationConfig().frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
                 }
             }
 
             SKBitmap? currentFrame = GetDisplayBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
+                DrawFrame(canvas, currentFrame, getCurrentFrameConfig().Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
             }
         }
         else
@@ -854,8 +836,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
             SKBitmap? previewFrame = GetDisplayBitmap(_previewFrames[previewFrameIndex]);
             if (previewFrame != null)
             {
-                IntVector2 previewOffset = previewFrameIndex < _animationConfig.frameCongfigs.Count
-                    ? _animationConfig.frameCongfigs[previewFrameIndex].Offset
+                IntVector2 previewOffset = previewFrameIndex < getCurrentAnimationConfig().frameCongfigs.Count
+                    ? getCurrentAnimationConfig().frameCongfigs[previewFrameIndex].Offset
                     : new IntVector2();
                 DrawFrame(canvas, previewFrame, previewOffset, zoom, axisX, axisY, width, height, 1f);
             }
@@ -931,7 +913,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void RemoveBackgroundToggleSwitch_Toggled(object sender, RoutedEventArgs e)
     {
-        _removeBackground = RemoveBackgroundToggleSwitch.IsOn;
         _backgroundRemovedCache.Clear();
         UpdateVisuals();
         UpdateAnimationPreviewFrame();

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -767,7 +767,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
             int dr = px.Red - bg.Red;
             int dg = px.Green - bg.Green;
             int db = px.Blue - bg.Blue;
-            double dist2 = (dr * dr) + (dg * dg) + (db * db);
+            int da = px.Alpha - bg.Alpha;
+            double dist2 = (dr * dr) + (dg * dg) + (db * db) + (da * da);
             dstPixels[i] = dist2 <= thresholdSquared ? new SKColor(0, 0, 0, 0) : px;
         }
 
@@ -798,18 +799,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
             return false;
         }
 
-        string normalized = hex.Trim().TrimStart('#');
-        if (normalized.Length != 6)
+        if (!ColorHelper.TryParse(hex, out byte a, out byte r, out byte g, out byte b))
         {
             return false;
         }
 
-        if (!uint.TryParse(normalized, System.Globalization.NumberStyles.HexNumber, null, out uint rgb))
-        {
-            return false;
-        }
-
-        color = new SKColor((byte)((rgb >> 16) & 0xFF), (byte)((rgb >> 8) & 0xFF), (byte)(rgb & 0xFF), 255);
+        color = new SKColor(r, g, b, a);
         return true;
     }
 

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -845,7 +845,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
             SKBitmap? currentFrame = GetDisplayBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, 1f);
             }
         }
         else

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -845,7 +845,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
             SKBitmap? currentFrame = GetDisplayBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
-                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, 1f);
+                DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
             }
         }
         else

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -132,10 +132,10 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void RebuildCheckerboardShader()
     {
-        _checkerboardUnitBitmap.SetPixel(0, 0, new SKColor(lightA, lightA, lightA, 255));
-        _checkerboardUnitBitmap.SetPixel(1, 1, new SKColor(lightA, lightA, lightA, 255));
-        _checkerboardUnitBitmap.SetPixel(1, 0, new SKColor(lightB, lightB, lightB, 255));
-        _checkerboardUnitBitmap.SetPixel(0, 1, new SKColor(lightB, lightB, lightB, 255));
+        _checkerboardUnitBitmap.SetPixel(0, 0, new SKColor((byte)lightA, (byte)lightA, (byte)lightA, (byte)255));
+        _checkerboardUnitBitmap.SetPixel(1, 1, new SKColor((byte)lightA, (byte)lightA, (byte)lightA, (byte)255));
+        _checkerboardUnitBitmap.SetPixel(1, 0, new SKColor((byte)lightB, (byte)lightB, (byte)lightB, (byte)255));
+        _checkerboardUnitBitmap.SetPixel(0, 1, new SKColor((byte)lightB, (byte)lightB, (byte)lightB, (byte)255));
         _checkerboardShader?.Dispose();
         _checkerboardShader = _checkerboardUnitBitmap.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat);
     }

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -901,12 +901,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
             (clippedDest.Right - destRect.Left) * invScaleX,
             (clippedDest.Bottom - destRect.Top) * invScaleY);
 
-        if (overridePaint == null && Math.Abs(alpha - 1f) < 0.0001f)
-        {
-            canvas.DrawBitmap(bitmap, sourceRect, clippedDest);
-            return;
-        }
-
         SKPaint paint = overridePaint ?? _spritePaint;
         paint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
         canvas.DrawBitmap(bitmap, sourceRect, clippedDest, paint);

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -901,6 +901,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
             (clippedDest.Right - destRect.Left) * invScaleX,
             (clippedDest.Bottom - destRect.Top) * invScaleY);
 
+        if (overridePaint == null && Math.Abs(alpha - 1f) < 0.0001f)
+        {
+            canvas.DrawBitmap(bitmap, sourceRect, clippedDest);
+            return;
+        }
+
         SKPaint paint = overridePaint ?? _spritePaint;
         paint.Color = new SKColor(255, 255, 255, (byte)(alpha * 255f));
         canvas.DrawBitmap(bitmap, sourceRect, clippedDest, paint);

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -58,12 +58,16 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
     private readonly Dictionary<WriteableBitmap, SKBitmap> _bitmapCache = [];
+    private readonly Dictionary<WriteableBitmap, SKBitmap> _backgroundRemovedCache = [];
     private readonly SKPaint _spritePaint = new() { IsAntialias = false };
     private readonly SKPaint _previousFramePaint = new() { IsAntialias = false };
     private readonly SKPaint _checkerboardPaint = new() { IsAntialias = false };
     private readonly SKPaint _axisPaint = new() { IsAntialias = false, Color = new SKColor(140, 140, 140, 200) };
     private SKShader? _checkerboardShader;
     private readonly SKBitmap _checkerboardUnitBitmap = new(2, 2, SKColorType.Bgra8888, SKAlphaType.Premul);
+    private bool _removeBackground;
+    private SKColor? _backgroundColor;
+    private int _colorThreshold = 100;
 
 
     public event Action<float, float>? RemoveMovementButtonClick;
@@ -201,6 +205,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         _previewFrames = frames;
         _bitmapCache.Clear();
+        _backgroundRemovedCache.Clear();
         foreach (WriteableBitmap frame in frames)
         {
             _ = GetSkBitmap(frame);
@@ -733,6 +738,81 @@ public sealed partial class FrameCoordinateEditor : UserControl
         return bmp;
     }
 
+    private SKBitmap? GetDisplayBitmap(WriteableBitmap? wb)
+    {
+        SKBitmap? source = GetSkBitmap(wb);
+        if (source == null)
+        {
+            return null;
+        }
+
+        if (!_removeBackground || _backgroundColor == null)
+        {
+            return source;
+        }
+
+        if (wb != null && _backgroundRemovedCache.TryGetValue(wb, out SKBitmap? cached))
+        {
+            return cached;
+        }
+
+        SKBitmap masked = new(source.Width, source.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        double thresholdSquared = _colorThreshold * _colorThreshold;
+        SKColor bg = _backgroundColor.Value;
+        var srcPixels = source.GetPixelSpan();
+        var dstPixels = masked.GetPixelSpan();
+        for (int i = 0; i < srcPixels.Length; i++)
+        {
+            SKColor px = srcPixels[i];
+            int dr = px.Red - bg.Red;
+            int dg = px.Green - bg.Green;
+            int db = px.Blue - bg.Blue;
+            double dist2 = (dr * dr) + (dg * dg) + (db * db);
+            dstPixels[i] = dist2 <= thresholdSquared ? new SKColor(0, 0, 0, 0) : px;
+        }
+
+        if (wb != null)
+        {
+            _backgroundRemovedCache[wb] = masked;
+        }
+
+        return masked;
+    }
+
+    public void SetBackgroundRemovalOptions(bool removeBackground, string? backgroundColorHex, int colorThreshold)
+    {
+        _removeBackground = removeBackground;
+        _colorThreshold = Math.Max(0, colorThreshold);
+        _backgroundColor = TryParseHexColor(backgroundColorHex, out SKColor parsedColor) ? parsedColor : null;
+        RemoveBackgroundToggleSwitch.IsOn = removeBackground;
+        _backgroundRemovedCache.Clear();
+        UpdateVisuals();
+        UpdateAnimationPreviewFrame();
+    }
+
+    private static bool TryParseHexColor(string? hex, out SKColor color)
+    {
+        color = default;
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return false;
+        }
+
+        string normalized = hex.Trim().TrimStart('#');
+        if (normalized.Length != 6)
+        {
+            return false;
+        }
+
+        if (!uint.TryParse(normalized, System.Globalization.NumberStyles.HexNumber, null, out uint rgb))
+        {
+            return false;
+        }
+
+        color = new SKColor((byte)((rgb >> 16) & 0xFF), (byte)((rgb >> 8) & 0xFF), (byte)(rgb & 0xFF), 255);
+        return true;
+    }
+
     private void CoordinateCanvas_PaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
     {
         DrawCanvas(e.Surface.Canvas, e.Info.Width, e.Info.Height, true);
@@ -767,14 +847,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
             if (ShowPreviousToggleSwitch.IsOn)
             {
                 int previousFrameIndex = _selectedFrame == 0 ? _previewFrames.Count - 1 : _selectedFrame - 1;
-                SKBitmap? previousFrame = GetSkBitmap(_previewFrames[previousFrameIndex]);
+                SKBitmap? previousFrame = GetDisplayBitmap(_previewFrames[previousFrameIndex]);
                 if (previousFrame != null)
                 {
                 DrawFrame(canvas, previousFrame, _animationConfig.frameCongfigs[previousFrameIndex].Offset, zoom, axisX, axisY, width, height, 0.5f, _previousFramePaint);
                 }
             }
 
-            SKBitmap? currentFrame = GetSkBitmap(GetCurrentFrame());
+            SKBitmap? currentFrame = GetDisplayBitmap(GetCurrentFrame());
             if (currentFrame != null)
             {
                 DrawFrame(canvas, currentFrame, _animationConfig.frameCongfigs[_selectedFrame].Offset, zoom, axisX, axisY, width, height, ShowPreviousToggleSwitch.IsOn ? 0.7f : 1f);
@@ -783,7 +863,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         else
         {
             int previewFrameIndex = Math.Clamp(_previewFrameIndex + GetFromValue(), GetFromValue(), GetToValue());
-            SKBitmap? previewFrame = GetSkBitmap(_previewFrames[previewFrameIndex]);
+            SKBitmap? previewFrame = GetDisplayBitmap(_previewFrames[previewFrameIndex]);
             if (previewFrame != null)
             {
                 IntVector2 previewOffset = previewFrameIndex < _animationConfig.frameCongfigs.Count
@@ -859,6 +939,14 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private void ShowPreviousToggleSwitch_Toggled(object sender, RoutedEventArgs e)
     {
         UpdateVisuals();
+    }
+
+    private void RemoveBackgroundToggleSwitch_Toggled(object sender, RoutedEventArgs e)
+    {
+        _removeBackground = RemoveBackgroundToggleSwitch.IsOn;
+        _backgroundRemovedCache.Clear();
+        UpdateVisuals();
+        UpdateAnimationPreviewFrame();
     }
 
     private void FromNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -759,8 +759,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
         SKBitmap masked = new(source.Width, source.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
         double thresholdSquared = _colorThreshold * _colorThreshold;
         SKColor bg = _backgroundColor.Value;
-        var srcPixels = source.GetPixelSpan();
-        var dstPixels = masked.GetPixelSpan();
+        SKColor[] srcPixels = source.Pixels;
+        SKColor[] dstPixels = masked.Pixels;
         for (int i = 0; i < srcPixels.Length; i++)
         {
             SKColor px = srcPixels[i];

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -763,20 +763,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
         }
 
         SKColor bg = _backgroundColor.Value;
-        byte[] pixels = masked.Bytes;
-        for (int i = 0; i < pixels.Length; i += 4)
-        {
-            byte pb = pixels[i + 0];
-            byte pg = pixels[i + 1];
-            byte pr = pixels[i + 2];
-            byte pa = pixels[i + 3];
-
-            if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, bg.Red, bg.Green, bg.Blue, bg.Alpha, _colorThreshold))
-            {
-                pixels[i + 3] = 0;
-            }
-        }
-        masked.NotifyPixelsChanged();
+        ColorHelper.RemoveColorWithThresholdInPlace(masked, bg.Red, bg.Green, bg.Blue, bg.Alpha, _colorThreshold);
 
         if (wb != null)
         {

--- a/FramesToMMSpriteResources/MainWindow.xaml
+++ b/FramesToMMSpriteResources/MainWindow.xaml
@@ -301,7 +301,7 @@
                                 <local:FrameCoordinateEditor x:Name="FrameCoordinateEditorControl"
                                                              HorizontalAlignment="Stretch"
                                                              VerticalAlignment="Stretch"/>
-                            <Border x:Name="FramesLoadingBorder" Background="{ThemeResource SmokeFillColorDefaultBrush}">
+                            <Border x:Name="FramesLoadingBorder" Background="{ThemeResource SmokeFillColorDefaultBrush}" AllowFocusOnInteraction="True">
                                 <ProgressRing/>
                             </Border>
                             

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1302,6 +1302,7 @@ namespace FramesToMMSpriteResources
 
             var subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
             subjectConfig.Sheet ??= new SheetConfig();
+            FrameCoordinateEditorControl.SetBackgroundRemovalOptions(subjectConfig.RemoveBackground, subjectConfig.BackgroundColor, subjectConfig.ColorTreshold);
 
             RemoveBackgroundCheckBox.IsChecked = subjectConfig.RemoveBackground;
             CropSpritesCheckBox.IsChecked = subjectConfig.CropSprites;
@@ -1602,10 +1603,12 @@ namespace FramesToMMSpriteResources
 
         private void ThresholdTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
+            int threshold = double.IsNaN(sender.Value) ? 100 : (int)sender.Value;
             foreach (SubjectConfig currentConfig in _currentConfigs)
             {
-                currentConfig.ColorTreshold = double.IsNaN(sender.Value) ? 100 : (int)sender.Value;
+                currentConfig.ColorTreshold = threshold;
             }
+            UpdateFrameEditorBackgroundOptionsFromSelection();
         }
 
         private void ResizeTextBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
@@ -1650,10 +1653,12 @@ namespace FramesToMMSpriteResources
 
         private void ClickRemoveBackground(object sender, RoutedEventArgs e)
         {
+            bool removeBackground = (sender as CheckBox)!.IsChecked!.Value;
             foreach (SubjectConfig currentConfig in _currentConfigs)
             {
-                currentConfig.RemoveBackground = (sender as CheckBox)!.IsChecked!.Value;
+                currentConfig.RemoveBackground = removeBackground;
             }
+            UpdateFrameEditorBackgroundOptionsFromSelection();
         }
 
         private void ClickIsHdCheckBox(object sender, RoutedEventArgs e)
@@ -1667,11 +1672,39 @@ namespace FramesToMMSpriteResources
         private void ColorTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             UpdateColorPreview();
+            string backgroundColor = (sender as TextBox)!.Text;
             foreach (SubjectConfig currentConfig in _currentConfigs)
             {
-                currentConfig.BackgroundColor = (sender as TextBox)!.Text;
+                currentConfig.BackgroundColor = backgroundColor;
             }
-           
+            UpdateFrameEditorBackgroundOptionsFromSelection();
+        }
+
+        private void UpdateFrameEditorBackgroundOptionsFromSelection()
+        {
+            TreeViewNode? node = TreeViewControl.SelectedNode;
+            if (node == null)
+            {
+                return;
+            }
+
+            var depth = ((TreeItem)node.Content).Depth;
+            if (depth != ItemDepth.Frame && depth != ItemDepth.Animation && depth != ItemDepth.Subject)
+            {
+                return;
+            }
+
+            TreeViewNode subjectNode = depth switch
+            {
+                ItemDepth.Subject => node,
+                ItemDepth.Animation => node.Parent!,
+                _ => node.Parent!.Parent!
+            };
+
+            string gameThemeName = ((TreeItem)subjectNode.Parent!.Content).Text;
+            string subjectName = ((TreeItem)subjectNode.Content).Text;
+            SubjectConfig subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
+            FrameCoordinateEditorControl.SetBackgroundRemovalOptions(subjectConfig.RemoveBackground, subjectConfig.BackgroundColor, subjectConfig.ColorTreshold);
         }
 
         private void UpdateColorPreview()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1302,7 +1302,7 @@ namespace FramesToMMSpriteResources
 
             var subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
             subjectConfig.Sheet ??= new SheetConfig();
-            FrameCoordinateEditorControl.SetBackgroundRemovalOptions(subjectConfig.RemoveBackground, subjectConfig.BackgroundColor, subjectConfig.ColorTreshold);
+    
 
             RemoveBackgroundCheckBox.IsChecked = subjectConfig.RemoveBackground;
             CropSpritesCheckBox.IsChecked = subjectConfig.CropSprites;
@@ -1415,7 +1415,8 @@ namespace FramesToMMSpriteResources
                 _currentConfigs.Add(ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName].frameCongfigs[int.Parse(selectedNodeName)]);
             }
 
-            var animationConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName].AnimationConfigs![animationName];
+            var subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
+            var animationConfig = subjectConfig.AnimationConfigs![animationName];
             int selectedIndex = int.Parse(frameName);
             var frameConfig = animationConfig.frameCongfigs[selectedIndex];
 
@@ -1423,7 +1424,7 @@ namespace FramesToMMSpriteResources
             cts = new();
             try
             {
-                await LoadCoordinateEditorAsync(cts.Token, gameThemeName, subjectName, animationName, animationConfig, frameName, selectedIndex, frameConfig);
+                await LoadCoordinateEditorAsync(cts.Token, gameThemeName, subjectName, animationName, subjectConfig, frameName, selectedIndex, frameConfig);
             }
             catch
             {
@@ -1435,7 +1436,7 @@ namespace FramesToMMSpriteResources
             }
         }
 
-        async Task LoadCoordinateEditorAsync(CancellationToken ct, string gameThemeName, string subjectName, string animationName, AnimationConfig animationConfig, string frameName, int selectedIndex, FrameConfig frameConfig)
+        async Task LoadCoordinateEditorAsync(CancellationToken ct, string gameThemeName, string subjectName, string animationName, SubjectConfig subjectConfig, string frameName, int selectedIndex, FrameConfig frameConfig)
         {
             string gameThemePath;
             if (IsUsingGameThemes)
@@ -1455,7 +1456,7 @@ namespace FramesToMMSpriteResources
 
                 var tempAnimationSpriteFrame = new AnimationSpriteFrame(_animationSpriteFrame.Path, []);
 
-                foreach (FrameConfig frameConfigInLoop in animationConfig.frameCongfigs)
+                foreach (FrameConfig frameConfigInLoop in subjectConfig.AnimationConfigs![animationName].frameCongfigs)
                 {
                     ct.ThrowIfCancellationRequested();
 
@@ -1499,12 +1500,12 @@ namespace FramesToMMSpriteResources
                     {
                         frameName = selectedNodeAfterContent.Text;
                         selectedIndex = int.Parse(frameName);
-                        frameConfig = animationConfig.frameCongfigs[selectedIndex];
+                        frameConfig = subjectConfig.AnimationConfigs![animationName].frameCongfigs[selectedIndex];
                     }
                 }
 
                 IsLoadingFrames = false;
-                FrameCoordinateEditorControl.LoadAnimation(_animationSpriteFrame.WriteableBitmaps, animationConfig);
+                FrameCoordinateEditorControl.LoadAnimation(_animationSpriteFrame.WriteableBitmaps, subjectConfig, animationName);
             }
 
             if (TreeViewControl.SelectedNode != null)
@@ -1704,7 +1705,6 @@ namespace FramesToMMSpriteResources
             string gameThemeName = ((TreeItem)subjectNode.Parent!.Content).Text;
             string subjectName = ((TreeItem)subjectNode.Content).Text;
             SubjectConfig subjectConfig = ProgramConfig.GameThemeConfigs![gameThemeName].SubjectConfigs![subjectName];
-            FrameCoordinateEditorControl.SetBackgroundRemovalOptions(subjectConfig.RemoveBackground, subjectConfig.BackgroundColor, subjectConfig.ColorTreshold);
         }
 
         private void UpdateColorPreview()

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -1375,7 +1375,7 @@ namespace FramesToMMSpriteResources
 
         async void DisplayFrameCongifAsync(TreeViewNode node, bool animate = true, bool nowGenerated = false)
         {
-            AnimateGeneratePanel(show: true);
+            
             var gameThemeName = (node.Parent.Parent.Parent.Content as TreeItem)!.Text;
             var subjectName = (node.Parent.Parent.Content as TreeItem)!.Text;
             var animationName = (node.Parent.Content as TreeItem)!.Text;
@@ -1395,7 +1395,7 @@ namespace FramesToMMSpriteResources
                 _animationSpriteFrame.Path = newPath;
                 cts?.Cancel();
             }
-
+            AnimateGeneratePanel(show: true);
             var selectedNode = (node.Content as TreeItem)!;
 
             HandleSelection(selectedNode, nowGenerated, [gameThemeName, subjectName, animationName]);

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -633,8 +633,6 @@ namespace FramesToMMSpriteResources
                 return;
 
             var (r, g, b, a) = parsedBackgroundColor.Value;
-            double thresholdSquared = subjectConfig.ColorTreshold * subjectConfig.ColorTreshold;
-
             var pixels = src.GetPixelSpan();
 
             int length = pixels.Length;
@@ -655,14 +653,7 @@ namespace FramesToMMSpriteResources
                     byte pr = pixels[idx + 2];
                     byte pa = pixels[idx + 3];
 
-                    int dr = pr - r;
-                    int dg = pg - g;
-                    int db = pb - b;
-                    int da = pa - a;
-
-                    int dist2 = dr * dr + dg * dg + db * db + da * da;
-
-                    if (dist2 <= thresholdSquared)
+                    if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, r, g, b, a, subjectConfig.ColorTreshold))
                         pixels[idx + 3] = 0;
                 }
             }
@@ -675,14 +666,7 @@ namespace FramesToMMSpriteResources
                 byte pr = pixels[i + 2];
                 byte pa = pixels[i + 3];
 
-                int dr = pr - r;
-                int dg = pg - g;
-                int db = pb - b;
-                int da = pa - a;
-
-                int dist2 = dr * dr + dg * dg + db * db + da * da;
-
-                if (dist2 <= thresholdSquared)
+                if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, r, g, b, a, subjectConfig.ColorTreshold))
                     pixels[i + 3] = 0;
             }
 

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -633,44 +633,7 @@ namespace FramesToMMSpriteResources
                 return;
 
             var (r, g, b, a) = parsedBackgroundColor.Value;
-            var pixels = src.GetPixelSpan();
-
-            int length = pixels.Length;
-            int i = 0;
-
-            // Process 4 pixels at once (16 bytes)
-            int simdWidth = Vector<byte>.Count;
-
-            for (; i <= length - simdWidth; i += simdWidth)
-            {
-                // SIMD doesn't map perfectly to RGBA logic,
-                for (int j = 0; j < simdWidth; j += 4)
-                {
-                    int idx = i + j;
-
-                    byte pb = pixels[idx + 0];
-                    byte pg = pixels[idx + 1];
-                    byte pr = pixels[idx + 2];
-                    byte pa = pixels[idx + 3];
-
-                    if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, r, g, b, a, subjectConfig.ColorTreshold))
-                        pixels[idx + 3] = 0;
-                }
-            }
-
-            // tail
-            for (; i < length; i += 4)
-            {
-                byte pb = pixels[i + 0];
-                byte pg = pixels[i + 1];
-                byte pr = pixels[i + 2];
-                byte pa = pixels[i + 3];
-
-                if (ColorHelper.IsWithinThreshold(pr, pg, pb, pa, r, g, b, a, subjectConfig.ColorTreshold))
-                    pixels[i + 3] = 0;
-            }
-
-            src.NotifyPixelsChanged();
+            ColorHelper.RemoveColorWithThresholdInPlace(src, r, g, b, a, subjectConfig.ColorTreshold);
         }
 
         private static SKBitmap ResizeBitmapNearest(SKBitmap source, int newW, int newH)


### PR DESCRIPTION
### Motivation
- Make the Frame Coordinate Editor honor the subject-level `background_color`, `color_threshold`, and `remove_background` settings so the editor canvases show frames with the background removed exactly like the processing script, and do so with good runtime performance.

### Description
- Named the editor toggle (`RemoveBackgroundToggleSwitch`) and wired a toggled handler to control editor rendering behavior via `RemoveBackgroundToggleSwitch_Toggled`.
- Added `GetDisplayBitmap(...)` and a `_backgroundRemovedCache` that generate a threshold-based background-removed `SKBitmap` (color-distance vs `background_color` using `color_threshold`) and cache the results to avoid per-frame reprocessing.
- Exposed `SetBackgroundRemovalOptions(...)` on `FrameCoordinateEditor` and wired `MainWindow` to call it when showing a subject and when the subject controls (`remove_background`, `background_color`, `color_threshold`) change so the editor updates live.
- Switched both the main canvas and the preview canvas draw paths to use the processed display bitmap and clear the processed cache only when options or frames change.

### Testing
- Attempted an automated build with `dotnet build`, but it failed because `dotnet` is not installed in this environment (no build performed).
- Verified files compile conceptually through local edits and committed the changes; no other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e67234148327a379b722eb03954c)