### PR TITLE
Respect frame coordinate offsets during sprite processing

### DIFF
--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -50,6 +50,19 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
     private readonly InputCursor _resizeCornerCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNortheastSouthwest);
     private readonly HashSet<Windows.System.VirtualKey> _heldNudgeKeys = [];
+    private static readonly Windows.System.VirtualKey[] NudgeTrackedKeys =
+    [
+        Windows.System.VirtualKey.W,
+        Windows.System.VirtualKey.A,
+        Windows.System.VirtualKey.S,
+        Windows.System.VirtualKey.D,
+        Windows.System.VirtualKey.Control,
+        Windows.System.VirtualKey.LeftControl,
+        Windows.System.VirtualKey.RightControl,
+        Windows.System.VirtualKey.Shift,
+        Windows.System.VirtualKey.LeftShift,
+        Windows.System.VirtualKey.RightShift,
+    ];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
     private int _nudgeHoldTick;
     private const int NudgeHoldDelayTicks = 10;
@@ -297,7 +310,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     }
 
     public void UnloadAnimation()
-    {     
+    {
+        ClearNudgeKeyState();
         LoadAnimation(new([], new(0,0)), _subjectConfig, _animationConfigName, null);
         UpdateVisuals();
     }
@@ -494,6 +508,28 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _heldNudgeKeys.Remove(key);
         UpdateNudgeMotionState(hadDirection);
         return true;
+    }
+
+    public void ClearNudgeKeyState()
+    {
+        _heldNudgeKeys.Clear();
+        _nudgeHoldTick = 0;
+        _nudgeHoldTimer.Stop();
+    }
+
+    public void SyncNudgeKeyState(Func<Windows.System.VirtualKey, bool> isKeyDown)
+    {
+        bool hadDirection = HasHeldDirectionKey();
+        _heldNudgeKeys.Clear();
+        foreach (var key in NudgeTrackedKeys)
+        {
+            if (isKeyDown(key))
+            {
+                _heldNudgeKeys.Add(key);
+            }
+        }
+
+        UpdateNudgeMotionState(hadDirection);
     }
 
     private void UpdateNudgeMotionState(bool hadDirectionBeforeChange)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.WindowsAppSDK.Runtime.Packages;
 using SkiaSharp;
@@ -45,6 +46,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private ResizeDirection _previewResizeDirection;
     private double _previewResizeStartWidth;
     private double _previewResizeStartHeight;
+    private double _previewResizeTargetWidth;
+    private double _previewResizeTargetHeight;
     private Vector2 _previewResizeStartPointer;
     private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
@@ -687,6 +690,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewResizeStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _previewResizeStartWidth = AnimationPreviewHostBorder.ActualWidth;
         _previewResizeStartHeight = AnimationPreviewHostBorder.ActualHeight;
+        _previewResizeTargetWidth = _previewResizeStartWidth;
+        _previewResizeTargetHeight = _previewResizeStartHeight;
+        AnimationPreviewHostBorder.RenderTransformOrigin = direction is ResizeDirection.Left or ResizeDirection.BottomLeft
+            ? new Windows.Foundation.Point(1, 0)
+            : new Windows.Foundation.Point(0, 0);
+        AnimationPreviewHostBorder.RenderTransform = new ScaleTransform();
         handle.CapturePointer(e.Pointer);
         e.Handled = true;
     }
@@ -705,18 +714,17 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         if (_previewResizeDirection is ResizeDirection.Left or ResizeDirection.BottomLeft)
         {
-            width = Math.Max(0, _previewResizeStartWidth - delta.X);          
+            width = _previewResizeStartWidth - delta.X;
         }
 
         if (_previewResizeDirection is ResizeDirection.Bottom or ResizeDirection.BottomLeft)
         {
-            height = Math.Max(0, _previewResizeStartHeight + delta.Y);        
+            height = _previewResizeStartHeight + delta.Y;
         }
 
-        _subjectConfig.PreviewSize = new((float)width, (float)height);
-        AnimationPreviewHostBorder.Width = width;
-        AnimationPreviewHostBorder.Height = height;
-        UpdateAnimationPreviewFrame();
+        _previewResizeTargetWidth = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
+        _previewResizeTargetHeight = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
+        ApplyPreviewResizeTransform();
         e.Handled = true;
     }
 
@@ -727,9 +735,45 @@ public sealed partial class FrameCoordinateEditor : UserControl
             handle.ReleasePointerCapture(e.Pointer);
         }
 
+        CommitPreviewResize();
         _previewResizeDirection = ResizeDirection.None;
         ProtectedCursor = null;
         e.Handled = true;
+    }
+
+
+    private static double ClampPreviewSize(double value, double min, double max)
+    {
+        double resolvedMax = double.IsNaN(max) || double.IsInfinity(max) || max <= 0
+            ? double.PositiveInfinity
+            : max;
+        return Math.Clamp(value, min, resolvedMax);
+    }
+
+    private void ApplyPreviewResizeTransform()
+    {
+        if (AnimationPreviewHostBorder.RenderTransform is not ScaleTransform scaleTransform)
+        {
+            scaleTransform = new ScaleTransform();
+            AnimationPreviewHostBorder.RenderTransform = scaleTransform;
+        }
+
+        scaleTransform.ScaleX = _previewResizeStartWidth <= 0 ? 1 : _previewResizeTargetWidth / _previewResizeStartWidth;
+        scaleTransform.ScaleY = _previewResizeStartHeight <= 0 ? 1 : _previewResizeTargetHeight / _previewResizeStartHeight;
+    }
+
+    private void CommitPreviewResize()
+    {
+        if (_previewResizeDirection == ResizeDirection.None)
+        {
+            return;
+        }
+
+        AnimationPreviewHostBorder.RenderTransform = null;
+        AnimationPreviewHostBorder.Width = _previewResizeTargetWidth;
+        AnimationPreviewHostBorder.Height = _previewResizeTargetHeight;
+        _subjectConfig.PreviewSize = new((float)_previewResizeTargetWidth, (float)_previewResizeTargetHeight);
+        UpdateAnimationPreviewFrame();
     }
 
     private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.WindowsAppSDK.Runtime.Packages;
 using SkiaSharp;
@@ -46,8 +45,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private ResizeDirection _previewResizeDirection;
     private double _previewResizeStartWidth;
     private double _previewResizeStartHeight;
-    private double _previewResizeTargetWidth;
-    private double _previewResizeTargetHeight;
     private Vector2 _previewResizeStartPointer;
     private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
@@ -690,12 +687,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewResizeStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _previewResizeStartWidth = AnimationPreviewHostBorder.ActualWidth;
         _previewResizeStartHeight = AnimationPreviewHostBorder.ActualHeight;
-        _previewResizeTargetWidth = _previewResizeStartWidth;
-        _previewResizeTargetHeight = _previewResizeStartHeight;
-        AnimationPreviewHostBorder.RenderTransformOrigin = direction is ResizeDirection.Left or ResizeDirection.BottomLeft
-            ? new Windows.Foundation.Point(1, 0)
-            : new Windows.Foundation.Point(0, 0);
-        AnimationPreviewHostBorder.RenderTransform = new ScaleTransform();
         handle.CapturePointer(e.Pointer);
         e.Handled = true;
     }
@@ -714,17 +705,18 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
         if (_previewResizeDirection is ResizeDirection.Left or ResizeDirection.BottomLeft)
         {
-            width = _previewResizeStartWidth - delta.X;
+            width = Math.Max(0, _previewResizeStartWidth - delta.X);          
         }
 
         if (_previewResizeDirection is ResizeDirection.Bottom or ResizeDirection.BottomLeft)
         {
-            height = _previewResizeStartHeight + delta.Y;
+            height = Math.Max(0, _previewResizeStartHeight + delta.Y);        
         }
 
-        _previewResizeTargetWidth = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
-        _previewResizeTargetHeight = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
-        ApplyPreviewResizeTransform();
+        _subjectConfig.PreviewSize = new((float)width, (float)height);
+        AnimationPreviewHostBorder.Width = width;
+        AnimationPreviewHostBorder.Height = height;
+        UpdateAnimationPreviewFrame();
         e.Handled = true;
     }
 
@@ -735,45 +727,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
             handle.ReleasePointerCapture(e.Pointer);
         }
 
-        CommitPreviewResize();
         _previewResizeDirection = ResizeDirection.None;
         ProtectedCursor = null;
         e.Handled = true;
-    }
-
-
-    private static double ClampPreviewSize(double value, double min, double max)
-    {
-        double resolvedMax = double.IsNaN(max) || double.IsInfinity(max) || max <= 0
-            ? double.PositiveInfinity
-            : max;
-        return Math.Clamp(value, min, resolvedMax);
-    }
-
-    private void ApplyPreviewResizeTransform()
-    {
-        if (AnimationPreviewHostBorder.RenderTransform is not ScaleTransform scaleTransform)
-        {
-            scaleTransform = new ScaleTransform();
-            AnimationPreviewHostBorder.RenderTransform = scaleTransform;
-        }
-
-        scaleTransform.ScaleX = _previewResizeStartWidth <= 0 ? 1 : _previewResizeTargetWidth / _previewResizeStartWidth;
-        scaleTransform.ScaleY = _previewResizeStartHeight <= 0 ? 1 : _previewResizeTargetHeight / _previewResizeStartHeight;
-    }
-
-    private void CommitPreviewResize()
-    {
-        if (_previewResizeDirection == ResizeDirection.None)
-        {
-            return;
-        }
-
-        AnimationPreviewHostBorder.RenderTransform = null;
-        AnimationPreviewHostBorder.Width = _previewResizeTargetWidth;
-        AnimationPreviewHostBorder.Height = _previewResizeTargetHeight;
-        _subjectConfig.PreviewSize = new((float)_previewResizeTargetWidth, (float)_previewResizeTargetHeight);
-        UpdateAnimationPreviewFrame();
     }
 
     private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.WindowsAppSDK.Runtime.Packages;
 using SkiaSharp;
@@ -45,6 +46,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private ResizeDirection _previewResizeDirection;
     private double _previewResizeStartWidth;
     private double _previewResizeStartHeight;
+    private double _previewResizeTargetWidth;
+    private double _previewResizeTargetHeight;
     private Vector2 _previewResizeStartPointer;
     private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
@@ -64,9 +67,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Windows.System.VirtualKey.RightShift,
     ];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
-    private readonly DispatcherTimer _canvasResizeTimer = new();
-    private bool _coordinateResizePending;
-    private bool _previewResizePending;
     private int _nudgeHoldTick;
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
@@ -111,9 +111,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _nudgeHoldTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _nudgeHoldTimer.Tick -= NudgeHoldTimer_Tick;
         _nudgeHoldTimer.Tick += NudgeHoldTimer_Tick;
-        _canvasResizeTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
-        _canvasResizeTimer.Tick -= CanvasResizeTimer_Tick;
-        _canvasResizeTimer.Tick += CanvasResizeTimer_Tick;
     
         ZoomNumberBox.Value = 100;
 
@@ -330,57 +327,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        _subjectConfig.EditorCanvas.Pan = PreserveCanvasOrigin(e.PreviousSize, e.NewSize, _subjectConfig.EditorCanvas.Pan);
-        ScheduleCoordinateCanvasRedraw();
-        UpdateZoomControls();
-    }
-
-    private void CanvasResizeTimer_Tick(object? sender, object e)
-    {
-        _canvasResizeTimer.Stop();
-
-        if (_coordinateResizePending)
-        {
-            _coordinateResizePending = false;
-            CoordinateCanvas.Invalidate();
-        }
-
-        if (_previewResizePending)
-        {
-            _previewResizePending = false;
-            AnimationPreviewCanvas.Invalidate();
-        }
-    }
-
-    private void ScheduleCoordinateCanvasRedraw()
-    {
-        _coordinateResizePending = true;
-        if (!_canvasResizeTimer.IsEnabled)
-        {
-            _canvasResizeTimer.Start();
-        }
-    }
-
-    private void SchedulePreviewCanvasRedraw()
-    {
-        _previewResizePending = true;
-        if (!_canvasResizeTimer.IsEnabled)
-        {
-            _canvasResizeTimer.Start();
-        }
-    }
-
-    private static Vector2 PreserveCanvasOrigin(Windows.Foundation.Size previousSize, Windows.Foundation.Size newSize, Vector2 pan)
-    {
-        if (previousSize.Width <= 0 || previousSize.Height <= 0 ||
-            newSize.Width <= 0 || newSize.Height <= 0)
-        {
-            return pan;
-        }
-
-        return pan + new Vector2(
-            (float)((previousSize.Width - newSize.Width) / 2.0),
-            (float)((previousSize.Height - newSize.Height) / 2.0));
+        UpdateVisuals();
     }
 
     private void CoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
@@ -644,8 +591,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void AnimationPreviewCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        _subjectConfig.PreviewCanvas.Pan = PreserveCanvasOrigin(e.PreviousSize, e.NewSize, _subjectConfig.PreviewCanvas.Pan);
-        SchedulePreviewCanvasRedraw();
+        UpdateAnimationPreviewFrame();
         //SetMaxPreviewSize();
     }
 
@@ -744,6 +690,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewResizeStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _previewResizeStartWidth = AnimationPreviewHostBorder.ActualWidth;
         _previewResizeStartHeight = AnimationPreviewHostBorder.ActualHeight;
+        _previewResizeTargetWidth = _previewResizeStartWidth;
+        _previewResizeTargetHeight = _previewResizeStartHeight;
+        AnimationPreviewHostBorder.RenderTransformOrigin = direction is ResizeDirection.Left or ResizeDirection.BottomLeft
+            ? new Windows.Foundation.Point(1, 0)
+            : new Windows.Foundation.Point(0, 0);
+        AnimationPreviewHostBorder.RenderTransform = new ScaleTransform();
         handle.CapturePointer(e.Pointer);
         e.Handled = true;
     }
@@ -770,12 +722,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
             height = _previewResizeStartHeight + delta.Y;
         }
 
-        width = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
-        height = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
-
-        _subjectConfig.PreviewSize = new((float)width, (float)height);
-        AnimationPreviewHostBorder.Width = width;
-        AnimationPreviewHostBorder.Height = height;
+        _previewResizeTargetWidth = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
+        _previewResizeTargetHeight = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
+        ApplyPreviewResizeTransform();
         e.Handled = true;
     }
 
@@ -786,6 +735,7 @@ public sealed partial class FrameCoordinateEditor : UserControl
             handle.ReleasePointerCapture(e.Pointer);
         }
 
+        CommitPreviewResize();
         _previewResizeDirection = ResizeDirection.None;
         ProtectedCursor = null;
         e.Handled = true;
@@ -800,6 +750,31 @@ public sealed partial class FrameCoordinateEditor : UserControl
         return Math.Clamp(value, min, resolvedMax);
     }
 
+    private void ApplyPreviewResizeTransform()
+    {
+        if (AnimationPreviewHostBorder.RenderTransform is not ScaleTransform scaleTransform)
+        {
+            scaleTransform = new ScaleTransform();
+            AnimationPreviewHostBorder.RenderTransform = scaleTransform;
+        }
+
+        scaleTransform.ScaleX = _previewResizeStartWidth <= 0 ? 1 : _previewResizeTargetWidth / _previewResizeStartWidth;
+        scaleTransform.ScaleY = _previewResizeStartHeight <= 0 ? 1 : _previewResizeTargetHeight / _previewResizeStartHeight;
+    }
+
+    private void CommitPreviewResize()
+    {
+        if (_previewResizeDirection == ResizeDirection.None)
+        {
+            return;
+        }
+
+        AnimationPreviewHostBorder.RenderTransform = null;
+        AnimationPreviewHostBorder.Width = _previewResizeTargetWidth;
+        AnimationPreviewHostBorder.Height = _previewResizeTargetHeight;
+        _subjectConfig.PreviewSize = new((float)_previewResizeTargetWidth, (float)_previewResizeTargetHeight);
+        UpdateAnimationPreviewFrame();
+    }
 
     private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {

--- a/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
+++ b/FramesToMMSpriteResources/FrameCoordinateEditor.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.WindowsAppSDK.Runtime.Packages;
 using SkiaSharp;
@@ -46,8 +45,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
     private ResizeDirection _previewResizeDirection;
     private double _previewResizeStartWidth;
     private double _previewResizeStartHeight;
-    private double _previewResizeTargetWidth;
-    private double _previewResizeTargetHeight;
     private Vector2 _previewResizeStartPointer;
     private readonly InputCursor _resizeLeftCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private readonly InputCursor _resizeBottomCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth);
@@ -67,6 +64,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
         Windows.System.VirtualKey.RightShift,
     ];
     private readonly DispatcherTimer _nudgeHoldTimer = new();
+    private readonly DispatcherTimer _canvasResizeTimer = new();
+    private bool _coordinateResizePending;
+    private bool _previewResizePending;
     private int _nudgeHoldTick;
     private const int NudgeHoldDelayTicks = 10;
     byte lightA, lightB;
@@ -111,6 +111,9 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _nudgeHoldTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
         _nudgeHoldTimer.Tick -= NudgeHoldTimer_Tick;
         _nudgeHoldTimer.Tick += NudgeHoldTimer_Tick;
+        _canvasResizeTimer.Interval = TimeSpan.FromSeconds(1.0 / 60.0);
+        _canvasResizeTimer.Tick -= CanvasResizeTimer_Tick;
+        _canvasResizeTimer.Tick += CanvasResizeTimer_Tick;
     
         ZoomNumberBox.Value = 100;
 
@@ -327,7 +330,57 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void CoordinateCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        UpdateVisuals();
+        _subjectConfig.EditorCanvas.Pan = PreserveCanvasOrigin(e.PreviousSize, e.NewSize, _subjectConfig.EditorCanvas.Pan);
+        ScheduleCoordinateCanvasRedraw();
+        UpdateZoomControls();
+    }
+
+    private void CanvasResizeTimer_Tick(object? sender, object e)
+    {
+        _canvasResizeTimer.Stop();
+
+        if (_coordinateResizePending)
+        {
+            _coordinateResizePending = false;
+            CoordinateCanvas.Invalidate();
+        }
+
+        if (_previewResizePending)
+        {
+            _previewResizePending = false;
+            AnimationPreviewCanvas.Invalidate();
+        }
+    }
+
+    private void ScheduleCoordinateCanvasRedraw()
+    {
+        _coordinateResizePending = true;
+        if (!_canvasResizeTimer.IsEnabled)
+        {
+            _canvasResizeTimer.Start();
+        }
+    }
+
+    private void SchedulePreviewCanvasRedraw()
+    {
+        _previewResizePending = true;
+        if (!_canvasResizeTimer.IsEnabled)
+        {
+            _canvasResizeTimer.Start();
+        }
+    }
+
+    private static Vector2 PreserveCanvasOrigin(Windows.Foundation.Size previousSize, Windows.Foundation.Size newSize, Vector2 pan)
+    {
+        if (previousSize.Width <= 0 || previousSize.Height <= 0 ||
+            newSize.Width <= 0 || newSize.Height <= 0)
+        {
+            return pan;
+        }
+
+        return pan + new Vector2(
+            (float)((previousSize.Width - newSize.Width) / 2.0),
+            (float)((previousSize.Height - newSize.Height) / 2.0));
     }
 
     private void CoordinateCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
@@ -591,7 +644,8 @@ public sealed partial class FrameCoordinateEditor : UserControl
 
     private void AnimationPreviewCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        UpdateAnimationPreviewFrame();
+        _subjectConfig.PreviewCanvas.Pan = PreserveCanvasOrigin(e.PreviousSize, e.NewSize, _subjectConfig.PreviewCanvas.Pan);
+        SchedulePreviewCanvasRedraw();
         //SetMaxPreviewSize();
     }
 
@@ -690,12 +744,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         _previewResizeStartPointer = new Vector2((float)point.Position.X, (float)point.Position.Y);
         _previewResizeStartWidth = AnimationPreviewHostBorder.ActualWidth;
         _previewResizeStartHeight = AnimationPreviewHostBorder.ActualHeight;
-        _previewResizeTargetWidth = _previewResizeStartWidth;
-        _previewResizeTargetHeight = _previewResizeStartHeight;
-        AnimationPreviewHostBorder.RenderTransformOrigin = direction is ResizeDirection.Left or ResizeDirection.BottomLeft
-            ? new Windows.Foundation.Point(1, 0)
-            : new Windows.Foundation.Point(0, 0);
-        AnimationPreviewHostBorder.RenderTransform = new ScaleTransform();
         handle.CapturePointer(e.Pointer);
         e.Handled = true;
     }
@@ -722,9 +770,12 @@ public sealed partial class FrameCoordinateEditor : UserControl
             height = _previewResizeStartHeight + delta.Y;
         }
 
-        _previewResizeTargetWidth = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
-        _previewResizeTargetHeight = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
-        ApplyPreviewResizeTransform();
+        width = ClampPreviewSize(width, AnimationPreviewHostBorder.MinWidth, AnimationPreviewHostBorder.MaxWidth);
+        height = ClampPreviewSize(height, AnimationPreviewHostBorder.MinHeight, AnimationPreviewHostBorder.MaxHeight);
+
+        _subjectConfig.PreviewSize = new((float)width, (float)height);
+        AnimationPreviewHostBorder.Width = width;
+        AnimationPreviewHostBorder.Height = height;
         e.Handled = true;
     }
 
@@ -735,7 +786,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
             handle.ReleasePointerCapture(e.Pointer);
         }
 
-        CommitPreviewResize();
         _previewResizeDirection = ResizeDirection.None;
         ProtectedCursor = null;
         e.Handled = true;
@@ -750,31 +800,6 @@ public sealed partial class FrameCoordinateEditor : UserControl
         return Math.Clamp(value, min, resolvedMax);
     }
 
-    private void ApplyPreviewResizeTransform()
-    {
-        if (AnimationPreviewHostBorder.RenderTransform is not ScaleTransform scaleTransform)
-        {
-            scaleTransform = new ScaleTransform();
-            AnimationPreviewHostBorder.RenderTransform = scaleTransform;
-        }
-
-        scaleTransform.ScaleX = _previewResizeStartWidth <= 0 ? 1 : _previewResizeTargetWidth / _previewResizeStartWidth;
-        scaleTransform.ScaleY = _previewResizeStartHeight <= 0 ? 1 : _previewResizeTargetHeight / _previewResizeStartHeight;
-    }
-
-    private void CommitPreviewResize()
-    {
-        if (_previewResizeDirection == ResizeDirection.None)
-        {
-            return;
-        }
-
-        AnimationPreviewHostBorder.RenderTransform = null;
-        AnimationPreviewHostBorder.Width = _previewResizeTargetWidth;
-        AnimationPreviewHostBorder.Height = _previewResizeTargetHeight;
-        _subjectConfig.PreviewSize = new((float)_previewResizeTargetWidth, (float)_previewResizeTargetHeight);
-        UpdateAnimationPreviewFrame();
-    }
 
     private void AnimationPreviewCanvas_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {

--- a/FramesToMMSpriteResources/MainWindow.xaml.cs
+++ b/FramesToMMSpriteResources/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Media;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using System.Threading;
@@ -158,6 +159,9 @@ namespace FramesToMMSpriteResources
 
         private bool _isCtrlHeld = false;
         public bool IsCtrlHeld => _isCtrlHeld;
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
 
         private bool _isGeneratePanelShowed = true;
 
@@ -363,6 +367,7 @@ namespace FramesToMMSpriteResources
                     _waitingForSecondaryActivation = false;
            
                     _isWindowActive = false;
+                    ClearKeyboardState();
                     CheckForAllowProgramEditing();
                     cts?.Cancel();
                     ReduceFileSizeCheckBox.Click -= ReduceFileSizeCheckBox_Click;
@@ -414,6 +419,7 @@ namespace FramesToMMSpriteResources
             await Task.Delay(1);
 
             CheckForAllowProgramEditing();
+            SyncKeyboardState();
         }
 
         private async void WorkingPathTextBox_LostFocus(object sender, RoutedEventArgs e)
@@ -1550,6 +1556,11 @@ namespace FramesToMMSpriteResources
 
                     OffsetXTextBox.ValueChanged += OffsetXTextBox_ValueChanged;
                     OffsetYTextBox.ValueChanged += OffsetYTextBox_ValueChanged;
+
+                    if (_isWindowActive)
+                    {
+                        SyncKeyboardState();
+                    }
                 }
             }
         }
@@ -2311,6 +2322,37 @@ namespace FramesToMMSpriteResources
             await Windows.System.Launcher.LaunchUriAsync(new Uri("file:///" + exeDir.Replace('\\', '/')));
         }
 
+        private void ClearKeyboardState()
+        {
+            _isCtrlHeld = false;
+            FrameCoordinateEditorControl.ClearNudgeKeyState();
+        }
+
+        private void SyncKeyboardState()
+        {
+            _isCtrlHeld = IsVirtualKeyDown(Windows.System.VirtualKey.Control) ||
+                          IsVirtualKeyDown(Windows.System.VirtualKey.LeftControl) ||
+                          IsVirtualKeyDown(Windows.System.VirtualKey.RightControl);
+
+            bool isFrameEditorOpen =
+                FramePanel.Visibility == Visibility.Visible &&
+                TreeViewControl.SelectedNode != null &&
+                (TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame &&
+                FrameCoordinateEditorControl.PreviewSpriteFrames.LoadedSpriteFrames.Count > 0;
+
+            if (isFrameEditorOpen)
+            {
+                FrameCoordinateEditorControl.SyncNudgeKeyState(IsVirtualKeyDown);
+            }
+            else
+            {
+                FrameCoordinateEditorControl.ClearNudgeKeyState();
+            }
+        }
+
+        private static bool IsVirtualKeyDown(Windows.System.VirtualKey key)
+            => (GetAsyncKeyState((int)key) & 0x8000) != 0;
+
         private void MainRootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
         {
             if (e.Key == Windows.System.VirtualKey.R && FramePanel.Visibility == Visibility.Visible)
@@ -2337,7 +2379,8 @@ namespace FramesToMMSpriteResources
             bool isFrameEditorOpen =
                 FramePanel.Visibility == Visibility.Visible &&
                 TreeViewControl.SelectedNode != null &&
-                (TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame;
+                (TreeViewControl.SelectedNode.Content as TreeItem)!.Depth == ItemDepth.Frame &&
+                FrameCoordinateEditorControl.PreviewSpriteFrames.LoadedSpriteFrames.Count > 0;
 
             if (isFrameEditorOpen && FrameCoordinateEditorControl.HandleNudgeKeyDown(e.Key))
             {

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -18,14 +18,16 @@ namespace FramesToMMSpriteResources
         public SKBitmap Image { get; }
         public IntVector2 OriginalSize { get; }
         public IntVector2 TrimOffset { get; }
+        public IntVector2 FrameOffset { get; }
         public string AnimationName { get; }
         public JsonObject? OldFrameJson { get; }
 
-        public ProcessedSprite(SKBitmap image, IntVector2 originalSize, IntVector2 trimOffset, string animationName, JsonObject? oldFrameJson)
+        public ProcessedSprite(SKBitmap image, IntVector2 originalSize, IntVector2 trimOffset, IntVector2 frameOffset, string animationName, JsonObject? oldFrameJson)
         {
             Image = image;
             OriginalSize = originalSize;
             TrimOffset = trimOffset;
+            FrameOffset = frameOffset;
             AnimationName = animationName;
             OldFrameJson = oldFrameJson;
         }
@@ -141,11 +143,7 @@ namespace FramesToMMSpriteResources
                 int spritesCount = 0;
                 string animationPath = Path.Combine(subjectPath, "raw", animationName);
 
-                var i = 0;
-
-                var spritePaths = Directory.GetFiles(animationPath)
-    .Where(p => Path.GetExtension(p) == ".png")
-    .ToArray();
+                var spritePaths = GetOrderedSpritePaths(animationPath, animationConfig);
 
                 var localSprites = new ProcessedSprite[spritePaths.Length];
 
@@ -157,6 +155,7 @@ namespace FramesToMMSpriteResources
                 Parallel.For(0, spritePaths.Length, parallelOptions, i =>
                 {
                     var spritePath = spritePaths[i];
+                    IntVector2 frameOffset = GetFrameOffset(animationConfig, i);
 
                     SKBitmap working = SKBitmap.Decode(spritePath)
                         ?? throw new InvalidOperationException($"Failed to decode sprite: {spritePath}");
@@ -169,18 +168,13 @@ namespace FramesToMMSpriteResources
                         if (subjectConfig.ResizeToPercent != 100 && subjectConfig.ResizeToPercent > 0)
                         {
                             var scale = subjectConfig.ResizeToPercent / 100.0;
-                            int newW = Math.Max(1, (int)(working.Width * scale + 0.5));
-                            int newH = Math.Max(1, (int)(working.Height * scale + 0.5));
-
-                            if (newW != working.Width || newH != working.Height)
+                            var resized = ResizeBitmapNearestFromOrigin(working, frameOffset, scale, out IntVector2 resizedFrameOffset);
+                            if (!ReferenceEquals(resized, working))
                             {
-                                var resized = ResizeBitmapNearest(working, newW, newH);
-                                if (!ReferenceEquals(resized, working))
-                                {
-                                    working.Dispose();
-                                    working = resized;
-                                }
+                                working.Dispose();
+                                working = resized;
                             }
+                            frameOffset = resizedFrameOffset;
                         }
 
                         var originalSize = new IntVector2(working.Width, working.Height);
@@ -210,7 +204,7 @@ namespace FramesToMMSpriteResources
 
                         JsonObject? oldJson = (list != null && i < list.Count) ? list[i] : null;
 
-                        localSprites[i] = new ProcessedSprite(working, originalSize, offset, animationName, oldJson);
+                        localSprites[i] = new ProcessedSprite(working, originalSize, offset, frameOffset, animationName, oldJson);
                         working = null;
                     }
                     finally
@@ -380,25 +374,41 @@ namespace FramesToMMSpriteResources
                     int trimTop = trim.Y;
                     int originalWidth = orig.X;
                     int originalHeight = orig.Y;
-
-                    if (!recover.X)
+                    int visibleWidth = (int)Math.Abs(rightScaled - leftScaled);
+                    int visibleHeight = (int)Math.Abs(bottomScaled - topScaled);
+                    if (gameThemeConfig.IsHd)
                     {
-                        trimLeft = 0;
-                        originalWidth = (int)Math.Abs(rightScaled - leftScaled);
-                        if (gameThemeConfig.IsHd) originalWidth *= 2;
+                        visibleWidth *= 2;
+                        visibleHeight *= 2;
                     }
-                    if (!recover.Y)
+
+                    double originOffsetX;
+                    if (recover.X)
                     {
-                        trimTop = 0;
-                        originalHeight = (int)Math.Abs(bottomScaled - topScaled);
-                        if (gameThemeConfig.IsHd) originalHeight *= 2;
+                        originOffsetX = -sprite.FrameOffset.X - trimLeft;
+                    }
+                    else
+                    {
+                        double defaultFrameOffsetX = -(originalWidth / 2.0);
+                        double frameOffsetDeltaX = sprite.FrameOffset.X - defaultFrameOffsetX;
+                        originOffsetX = visibleWidth / 2.0 - frameOffsetDeltaX;
+                    }
+
+                    double originOffsetY;
+                    if (recover.Y)
+                    {
+                        originOffsetY = sprite.FrameOffset.Y - trimTop;
+                    }
+                    else
+                    {
+                        double defaultFrameOffsetY = originalHeight;
+                        double frameOffsetDeltaY = sprite.FrameOffset.Y - defaultFrameOffsetY;
+                        originOffsetY = visibleHeight - frameOffsetDeltaY;
                     }
 
                     var extra = animConfig.Offset;
-                    double originOffsetX = originalWidth / 2.0 - trimLeft;
-                    double originOffsetY = originalHeight - trimTop;
-                    originOffsetX += extra.Value.X;
-                    originOffsetY += extra.Value.Y;
+                    originOffsetX += extra?.X ?? 0;
+                    originOffsetY += extra?.Y ?? 0;
 
                     if (gameThemeConfig.IsHd)
                     {
@@ -638,6 +648,40 @@ namespace FramesToMMSpriteResources
             ColorHelper.RemoveColorWithThresholdInPlace(src, r, g, b, a, subjectConfig.ColorTreshold);
         }
 
+
+
+        private static string[] GetOrderedSpritePaths(string animationPath, AnimationConfig animationConfig)
+        {
+            if (animationConfig.FrameCongfigs != null && animationConfig.FrameCongfigs.Count > 0)
+            {
+                var orderedPaths = animationConfig.FrameCongfigs
+                    .Where(frameConfig => !string.IsNullOrWhiteSpace(frameConfig.Name))
+                    .Select(frameConfig => Path.Combine(animationPath, $"{frameConfig.Name}.png"))
+                    .Where(File.Exists)
+                    .ToArray();
+
+                if (orderedPaths.Length > 0)
+                    return orderedPaths;
+            }
+
+            return Directory.GetFiles(animationPath)
+                .Where(p => string.Equals(Path.GetExtension(p), ".png", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static IntVector2 GetFrameOffset(AnimationConfig animationConfig, int frameIndex)
+        {
+            if (animationConfig.FrameCongfigs != null &&
+                frameIndex >= 0 &&
+                frameIndex < animationConfig.FrameCongfigs.Count)
+            {
+                return animationConfig.FrameCongfigs[frameIndex].Offset;
+            }
+
+            return new IntVector2(0, 0);
+        }
+
         private static SKBitmap ResizeBitmapNearest(SKBitmap source, int newW, int newH)
         {
             if (newW == source.Width && newH == source.Height)
@@ -650,11 +694,47 @@ namespace FramesToMMSpriteResources
 
             var fallback = new SKBitmap(new SKImageInfo(newW, newH, source.ColorType, source.AlphaType));
             using (var canvas = new SKCanvas(fallback))
+            using (var paint = new SKPaint { IsAntialias = false })
             {
                 canvas.Clear(SKColors.Transparent);
-                canvas.DrawBitmap(source, new SKRect(0, 0, newW, newH));
+                canvas.DrawBitmap(source, new SKRect(0, 0, newW, newH), new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
             }
             return fallback;
+        }
+
+
+        private static SKBitmap ResizeBitmapNearestFromOrigin(SKBitmap source, IntVector2 frameOffset, double scale, out IntVector2 resizedFrameOffset)
+        {
+            double left = frameOffset.X;
+            double top = -frameOffset.Y;
+            double right = left + source.Width;
+            double bottom = top + source.Height;
+
+            int scaledLeft = RoundHalfUp(left * scale);
+            int scaledTop = RoundHalfUp(top * scale);
+            int scaledRight = RoundHalfUp(right * scale);
+            int scaledBottom = RoundHalfUp(bottom * scale);
+
+            int newW = Math.Max(1, scaledRight - scaledLeft);
+            int newH = Math.Max(1, scaledBottom - scaledTop);
+            resizedFrameOffset = new IntVector2(scaledLeft, -scaledTop);
+
+            if (scale == 1.0 && newW == source.Width && newH == source.Height && resizedFrameOffset == frameOffset)
+                return source;
+
+            var resized = new SKBitmap(new SKImageInfo(newW, newH, source.ColorType, source.AlphaType));
+            using (var canvas = new SKCanvas(resized))
+            using (var paint = new SKPaint { IsAntialias = false })
+            {
+                canvas.Clear(SKColors.Transparent);
+                var destRect = new SKRect(
+                    (float)(left * scale - scaledLeft),
+                    (float)(top * scale - scaledTop),
+                    (float)(right * scale - scaledLeft),
+                    (float)(bottom * scale - scaledTop));
+                canvas.DrawBitmap(source, destRect, new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
+            }
+            return resized;
         }
 
         private static (SKBitmap cropped, IntVector2 offset) TrimColor(SKBitmap src)

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -412,8 +412,8 @@ namespace FramesToMMSpriteResources
 
                     if (gameThemeConfig.IsHd)
                     {
-                        originOffsetX = RoundAwayFromZero(originOffsetX * scaleX);
-                        originOffsetY = RoundAwayFromZero(originOffsetY * scaleY);
+                        originOffsetX = ScaleHdOffset(originOffsetX);
+                        originOffsetY = ScaleHdOffset(originOffsetY);
                     }
                     else
                     {
@@ -798,6 +798,10 @@ namespace FramesToMMSpriteResources
         }
 
         private static int EnsureEvenValue(int v) => (v % 2 == 0) ? v : v + 1;
+
+
+        private static double ScaleHdOffset(double hdPixelOffset)
+            => RoundAwayFromZero(hdPixelOffset) / 2.0;
 
         private static int RoundHalfUp(double value) => (int)Math.Floor(value + 0.5);
 

--- a/FramesToMMSpriteResources/Processer.cs
+++ b/FramesToMMSpriteResources/Processer.cs
@@ -694,10 +694,11 @@ namespace FramesToMMSpriteResources
 
             var fallback = new SKBitmap(new SKImageInfo(newW, newH, source.ColorType, source.AlphaType));
             using (var canvas = new SKCanvas(fallback))
+            using (var image = SKImage.FromBitmap(source))
             using (var paint = new SKPaint { IsAntialias = false })
             {
                 canvas.Clear(SKColors.Transparent);
-                canvas.DrawBitmap(source, new SKRect(0, 0, newW, newH), new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
+                canvas.DrawImage(image, new SKRect(0, 0, newW, newH), new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
             }
             return fallback;
         }
@@ -724,6 +725,7 @@ namespace FramesToMMSpriteResources
 
             var resized = new SKBitmap(new SKImageInfo(newW, newH, source.ColorType, source.AlphaType));
             using (var canvas = new SKCanvas(resized))
+            using (var image = SKImage.FromBitmap(source))
             using (var paint = new SKPaint { IsAntialias = false })
             {
                 canvas.Clear(SKColors.Transparent);
@@ -732,7 +734,7 @@ namespace FramesToMMSpriteResources
                     (float)(top * scale - scaledTop),
                     (float)(right * scale - scaledLeft),
                     (float)(bottom * scale - scaledTop));
-                canvas.DrawBitmap(source, destRect, new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
+                canvas.DrawImage(image, destRect, new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None), paint);
             }
             return resized;
         }


### PR DESCRIPTION
### Motivation
- Processing must honor per-frame offsets set in the frame coordinate editor so generated sprites remain pixel-aligned with the full-resolution frames after resizing and trimming. 
- Resizing needs to be performed around each frame's configured origin so the pixelated output keeps the same visual placement as in the editor.

### Description
- Added `FrameOffset` to `ProcessedSprite` and carry per-frame editor offsets through the processing pipeline via the new helper `GetFrameOffset`.
- Load raw PNGs in configuration order with `GetOrderedSpritePaths` so offsets map to the intended frames, and pass each frame's offset into processing loops.
- Implemented `ResizeBitmapNearestFromOrigin` and switched resize logic to scale around the configured origin, returning a resized frame offset; integrated this into the resize flow and replaced the old nearest-resize fallback to use explicit nearest sampling.
- Compute exported metadata `Offset` from the preserved `FrameOffset` while preserving the `RecoverCroppedOffset` semantics and applying animation-level extra offsets (`AnimationConfig.Offset`).

### Testing
- Ran `git diff --check` to verify no obvious whitespace or index issues and inspected the generated diff, which was clean.
- Verified code edits with file diffs and local text inspection of `FramesToMMSpriteResources/Processer.cs` to confirm helper functions and resized-offset logic were added.
- Attempted to run `dotnet --version` but the `dotnet` CLI is not available in this environment so no build/test was executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197303c4a48327b34e84b02866ce4c)